### PR TITLE
Derive Clone and Debug for collections

### DIFF
--- a/src/collections/all.rs
+++ b/src/collections/all.rs
@@ -29,6 +29,7 @@ use serde::{Deserialize, Deserializer, Error as SerdeError, Serialize, Serialize
 use serde_json::{Value, from_value};
 
 /// A basic event, room event, or state event.
+#[derive(Clone, Debug)]
 pub enum Event {
     /// m.call.answer
     CallAnswer(AnswerEvent),
@@ -83,6 +84,7 @@ pub enum Event {
 }
 
 /// A room event or state event.
+#[derive(Clone, Debug)]
 pub enum RoomEvent {
     /// m.call.answer
     CallAnswer(AnswerEvent),
@@ -127,6 +129,7 @@ pub enum RoomEvent {
 }
 
 /// A state event.
+#[derive(Clone, Debug)]
 pub enum StateEvent {
     /// m.room.aliases
     RoomAliases(AliasesEvent),

--- a/src/collections/only.rs
+++ b/src/collections/only.rs
@@ -19,6 +19,7 @@ use serde_json::{Value, from_value};
 pub use super::all::StateEvent;
 
 /// A basic event.
+#[derive(Clone, Debug)]
 pub enum Event {
     /// m.presence
     Presence(PresenceEvent),
@@ -33,6 +34,7 @@ pub enum Event {
 }
 
 /// A room event.
+#[derive(Clone, Debug)]
 pub enum RoomEvent {
     /// m.call.answer
     CallAnswer(AnswerEvent),


### PR DESCRIPTION
The following code fails because the collections don't implement Clone and Debug. Since they are pretty common traits they should be derived, unless I'm missing something.
```rust
extern crate ruma_events;
use ruma_events::collections::all::Event;

#[derive(Clone, Debug)]
struct A {
  pub b: String,
  pub c: Vec<Event>,
}

fn main() {
  let container = Vec::<Event>::new();

  A { 
    b: "".to_string(),
    c: container,
  };
}
```
```
 --> src/main.rs:8:5
  |
8 |     pub c: Vec<Event>>,
  |     ^^^^^^^^^^^^^^^^^^^^^^ the trait `std::clone::Clone` is not implemented for `ruma_events::collections::all::Event`
  |

--> src/main.rs:8:5
  |
8 |     pub c: Vec<Event>,
  |     ^^^^^^^^^^^^^^^^^^^^^^ the trait `std::fmt::Debug` is not implemented for `ruma_events::collections::all::Event`
```