### PR TITLE
Update matrix events to their latest version

### DIFF
--- a/src/call/answer.rs
+++ b/src/call/answer.rs
@@ -10,7 +10,7 @@ room_event! {
 /// The payload of an `AnswerEvent`.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AnswerEventContent {
-    /// The VoIP session description.
+    /// The VoIP session description object. The session description type must be *answer*.
     pub answer: SessionDescription,
     /// The ID of the call this event relates to.
     pub call_id: String,

--- a/src/call/invite.rs
+++ b/src/call/invite.rs
@@ -16,7 +16,7 @@ pub struct InviteEventContent {
     /// value, clients should discard it. They should also no longer show the call as awaiting an
     /// answer in the UI.
     pub lifetime: u64,
-    /// The session description object.
+    /// The session description object. The session description type must be *offer*.
     pub offer: SessionDescription,
     /// The version of the VoIP specification this messages adheres to.
     pub version: u64,

--- a/src/collections/all.rs
+++ b/src/collections/all.rs
@@ -19,6 +19,7 @@ use room::join_rules::JoinRulesEvent;
 use room::member::MemberEvent;
 use room::message::MessageEvent;
 use room::name::NameEvent;
+use room::pinned_events::PinnedEventsEvent;
 use room::power_levels::PowerLevelsEvent;
 use room::redaction::RedactionEvent;
 use room::third_party_invite::ThirdPartyInviteEvent;
@@ -67,6 +68,8 @@ pub enum Event {
     RoomMessage(MessageEvent),
     /// m.room.name
     RoomName(NameEvent),
+    /// m.room.pinned_events
+    RoomPinnedEvents(PinnedEventsEvent),
     /// m.room.power_levels
     RoomPowerLevels(PowerLevelsEvent),
     /// m.room.redaction
@@ -118,6 +121,8 @@ pub enum RoomEvent {
     RoomMessage(MessageEvent),
     /// m.room.name
     RoomName(NameEvent),
+    /// m.room.pinned_events
+    RoomPinnedEvents(PinnedEventsEvent),
     /// m.room.power_levels
     RoomPowerLevels(PowerLevelsEvent),
     /// m.room.redaction
@@ -153,6 +158,8 @@ pub enum StateEvent {
     RoomMember(MemberEvent),
     /// m.room.name
     RoomName(NameEvent),
+    /// m.room.pinned_events
+    RoomPinnedEvents(PinnedEventsEvent),
     /// m.room.power_levels
     RoomPowerLevels(PowerLevelsEvent),
     /// m.room.third_party_invite
@@ -183,6 +190,7 @@ impl Serialize for Event {
             Event::RoomMember(ref event) => event.serialize(serializer),
             Event::RoomMessage(ref event) => event.serialize(serializer),
             Event::RoomName(ref event) => event.serialize(serializer),
+            Event::RoomPinnedEvents(ref event) => event.serialize(serializer),
             Event::RoomPowerLevels(ref event) => event.serialize(serializer),
             Event::RoomRedaction(ref event) => event.serialize(serializer),
             Event::RoomThirdPartyInvite(ref event) => event.serialize(serializer),
@@ -347,6 +355,14 @@ impl<'de> Deserialize<'de> for Event {
 
                 Ok(Event::RoomName(event))
             }
+            EventType::RoomPinnedEvents => {
+                let event = match from_value::<PinnedEventsEvent>(value) {
+                    Ok(event) => event,
+                    Err(error) => return Err(D::Error::custom(error.to_string())),
+                };
+
+                Ok(Event::RoomPinnedEvents(event))
+            }
             EventType::RoomPowerLevels => {
                 let event = match from_value::<PowerLevelsEvent>(value) {
                     Ok(event) => event,
@@ -441,6 +457,7 @@ impl Serialize for RoomEvent {
             RoomEvent::RoomMember(ref event) => event.serialize(serializer),
             RoomEvent::RoomMessage(ref event) => event.serialize(serializer),
             RoomEvent::RoomName(ref event) => event.serialize(serializer),
+            RoomEvent::RoomPinnedEvents(ref event) => event.serialize(serializer),
             RoomEvent::RoomPowerLevels(ref event) => event.serialize(serializer),
             RoomEvent::RoomRedaction(ref event) => event.serialize(serializer),
             RoomEvent::RoomThirdPartyInvite(ref event) => event.serialize(serializer),
@@ -578,6 +595,14 @@ impl<'de> Deserialize<'de> for RoomEvent {
 
                 Ok(RoomEvent::RoomName(event))
             }
+            EventType::RoomPinnedEvents => {
+                let event = match from_value::<PinnedEventsEvent>(value) {
+                    Ok(event) => event,
+                    Err(error) => return Err(D::Error::custom(error.to_string())),
+                };
+
+                Ok(RoomEvent::RoomPinnedEvents(event))
+            }
             EventType::RoomPowerLevels => {
                 let event = match from_value::<PowerLevelsEvent>(value) {
                     Ok(event) => event,
@@ -650,6 +675,7 @@ impl Serialize for StateEvent {
             StateEvent::RoomJoinRules(ref event) => event.serialize(serializer),
             StateEvent::RoomMember(ref event) => event.serialize(serializer),
             StateEvent::RoomName(ref event) => event.serialize(serializer),
+            StateEvent::RoomPinnedEvents(ref event) => event.serialize(serializer),
             StateEvent::RoomPowerLevels(ref event) => event.serialize(serializer),
             StateEvent::RoomThirdPartyInvite(ref event) => event.serialize(serializer),
             StateEvent::RoomTopic(ref event) => event.serialize(serializer),
@@ -745,6 +771,14 @@ impl<'de> Deserialize<'de> for StateEvent {
 
                 Ok(StateEvent::RoomName(event))
             }
+            EventType::RoomPinnedEvents => {
+                let event = match from_value::<PinnedEventsEvent>(value) {
+                    Ok(event) => event,
+                    Err(error) => return Err(D::Error::custom(error.to_string())),
+                };
+
+                Ok(StateEvent::RoomPinnedEvents(event))
+            }
             EventType::RoomPowerLevels => {
                 let event = match from_value::<PowerLevelsEvent>(value) {
                     Ok(event) => event,
@@ -821,6 +855,7 @@ impl_from_t_for_event!(JoinRulesEvent, RoomJoinRules);
 impl_from_t_for_event!(MemberEvent, RoomMember);
 impl_from_t_for_event!(MessageEvent, RoomMessage);
 impl_from_t_for_event!(NameEvent, RoomName);
+impl_from_t_for_event!(PinnedEventsEvent, RoomPinnedEvents);
 impl_from_t_for_event!(PowerLevelsEvent, RoomPowerLevels);
 impl_from_t_for_event!(RedactionEvent, RoomRedaction);
 impl_from_t_for_event!(ThirdPartyInviteEvent, RoomThirdPartyInvite);
@@ -855,6 +890,7 @@ impl_from_t_for_room_event!(JoinRulesEvent, RoomJoinRules);
 impl_from_t_for_room_event!(MemberEvent, RoomMember);
 impl_from_t_for_room_event!(MessageEvent, RoomMessage);
 impl_from_t_for_room_event!(NameEvent, RoomName);
+impl_from_t_for_room_event!(PinnedEventsEvent, RoomPinnedEvents);
 impl_from_t_for_room_event!(PowerLevelsEvent, RoomPowerLevels);
 impl_from_t_for_room_event!(RedactionEvent, RoomRedaction);
 impl_from_t_for_room_event!(ThirdPartyInviteEvent, RoomThirdPartyInvite);
@@ -881,6 +917,7 @@ impl_from_t_for_state_event!(HistoryVisibilityEvent, RoomHistoryVisibility);
 impl_from_t_for_state_event!(JoinRulesEvent, RoomJoinRules);
 impl_from_t_for_state_event!(MemberEvent, RoomMember);
 impl_from_t_for_state_event!(NameEvent, RoomName);
+impl_from_t_for_state_event!(PinnedEventsEvent, RoomPinnedEvents);
 impl_from_t_for_state_event!(PowerLevelsEvent, RoomPowerLevels);
 impl_from_t_for_state_event!(ThirdPartyInviteEvent, RoomThirdPartyInvite);
 impl_from_t_for_state_event!(TopicEvent, RoomTopic);

--- a/src/collections/only.rs
+++ b/src/collections/only.rs
@@ -136,8 +136,9 @@ impl<'de> Deserialize<'de> for Event {
             EventType::CallInvite | EventType::RoomAliases | EventType::RoomAvatar |
             EventType::RoomCanonicalAlias | EventType::RoomCreate | EventType::RoomGuestAccess |
             EventType::RoomHistoryVisibility | EventType::RoomJoinRules | EventType::RoomMember |
-            EventType::RoomMessage | EventType::RoomName | EventType::RoomPowerLevels |
-            EventType::RoomRedaction | EventType::RoomThirdPartyInvite | EventType::RoomTopic => {
+            EventType::RoomMessage | EventType::RoomName | EventType::RoomPinnedEvents |
+            EventType::RoomPowerLevels | EventType::RoomRedaction | EventType::RoomThirdPartyInvite |
+            EventType::RoomTopic => {
                 return Err(D::Error::custom("not exclusively a basic event".to_string()));
             }
         }
@@ -241,6 +242,7 @@ impl<'de> Deserialize<'de> for RoomEvent {
             EventType::RoomJoinRules |
             EventType::RoomMember |
             EventType::RoomName |
+            EventType::RoomPinnedEvents |
             EventType::RoomPowerLevels |
             EventType::RoomThirdPartyInvite |
             EventType::RoomTopic |

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -1,0 +1,93 @@
+//! Types for the *m.direct* event.
+
+use std::collections::HashMap;
+
+use ruma_identifiers::{UserId, RoomId};
+
+event! {
+    /// Informs the client about the rooms that are considered direct by a user.
+    pub struct DirectEvent(DirectEventContent) {}
+}
+
+/// The payload of a `DirectEvent`.
+///
+/// A mapping of `UserId`'s to a collection of `RoomId`'s which are considered
+/// *direct* for that particular user.
+pub type DirectEventContent = HashMap<UserId, Vec<RoomId>>;
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use ruma_identifiers::{UserId, RoomId};
+    use serde_json::{from_str, to_string};
+
+    use collections;
+    use direct::{DirectEvent, DirectEventContent};
+    use super::super::EventType;
+
+    #[test]
+    fn serialization() {
+        let mut content: DirectEventContent = HashMap::new();
+        let alice = UserId::new("ruma.io").unwrap();
+        let room = vec![RoomId::new("ruma.io").unwrap()];
+
+        content.insert(alice.clone(), room.clone());
+
+        let event = DirectEvent {
+            content: content,
+            event_type: EventType::Direct,
+        };
+
+        assert_eq!(
+            to_string(&event).unwrap(),
+            format!(
+                r#"{{"content":{{"{}":["{}"]}},"type":"m.direct"}}"#,
+                alice.to_string(), room[0].to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn deserialization() {
+        let alice = UserId::new("ruma.io").unwrap();
+        let rooms = vec![
+            RoomId::new("ruma.io").unwrap(),
+            RoomId::new("ruma.io").unwrap()
+        ];
+
+        let json_data = format!(r#"{{
+            "content": {{ "{}": ["{}", "{}"] }},
+            "type": "m.direct"
+        }}"#, alice.to_string(), rooms[0].to_string(), rooms[1].to_string());
+
+        let event = from_str::<DirectEvent>(&json_data).unwrap();
+        assert_eq!(event.event_type, EventType::Direct);
+
+        let direct_rooms = event.content.get(&alice).unwrap();
+        assert!(direct_rooms.contains(&rooms[0]));
+        assert!(direct_rooms.contains(&rooms[1]));
+
+        match from_str::<collections::all::Event>(&json_data).unwrap() {
+            collections::all::Event::Direct(event) => {
+                assert_eq!(event.event_type, EventType::Direct);
+
+                let direct_rooms = event.content.get(&alice).unwrap();
+                assert!(direct_rooms.contains(&rooms[0]));
+                assert!(direct_rooms.contains(&rooms[1]));
+            },
+            _ => assert!(false)
+        };
+
+        match from_str::<collections::only::Event>(&json_data).unwrap() {
+            collections::only::Event::Direct(event) => {
+                assert_eq!(event.event_type, EventType::Direct);
+
+                let direct_rooms = event.content.get(&alice).unwrap();
+                assert!(direct_rooms.contains(&rooms[0]));
+                assert!(direct_rooms.contains(&rooms[1]));
+            },
+            _ => assert!(false)
+        };
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,6 +169,8 @@ pub enum EventType {
     RoomMessage,
     /// m.room.name
     RoomName,
+    /// m.room.pinned_events
+    RoomPinnedEvents,
     /// m.room.power_levels
     RoomPowerLevels,
     /// m.room.redaction
@@ -259,6 +261,7 @@ impl Display for EventType {
             EventType::RoomMember => "m.room.member",
             EventType::RoomMessage => "m.room.message",
             EventType::RoomName => "m.room.name",
+            EventType::RoomPinnedEvents=> "m.room.pinned_events",
             EventType::RoomPowerLevels => "m.room.power_levels",
             EventType::RoomRedaction => "m.room.redaction",
             EventType::RoomThirdPartyInvite => "m.room.third_party_invite",
@@ -292,6 +295,7 @@ impl<'a> From<&'a str> for EventType {
             "m.room.member" => EventType::RoomMember,
             "m.room.message" => EventType::RoomMessage,
             "m.room.name" => EventType::RoomName,
+            "m.room.pinned_events" => EventType::RoomPinnedEvents,
             "m.room.power_levels" => EventType::RoomPowerLevels,
             "m.room.redaction" => EventType::RoomRedaction,
             "m.room.third_party_invite" => EventType::RoomThirdPartyInvite,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,12 +192,6 @@ pub trait Event where Self: Debug + for<'a> Deserialize<'a> + Serialize {
 
     /// The type of the event.
     fn event_type(&self) -> &EventType;
-
-    /// Extra top-level key-value pairs specific to this event type, but that are not under the
-    /// `content` field.
-    fn extra_content(&self) -> Option<Value> {
-        None
-    }
 }
 
 /// An event within the context of a room.
@@ -205,14 +199,17 @@ pub trait RoomEvent: Event {
     /// The unique identifier for the event.
     fn event_id(&self) -> &EventId;
 
+    /// Timestamp in milliseconds on originating homeserver when this event was sent.
+    fn origin_server_ts(&self) -> u64;
+
     /// The unique identifier for the room associated with this event.
     fn room_id(&self) -> &RoomId;
 
+    /// The unique identifier for the user who sent this event.
+    fn sender(&self) -> &UserId;
+
     /// Additional key-value pairs not signed by the homeserver.
     fn unsigned(&self) -> Option<&Value>;
-
-    /// The unique identifier for the user associated with this event.
-    fn user_id(&self) -> &UserId;
 }
 
 /// An event that describes persistent state about a room.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,6 +120,7 @@ pub mod collections {
     pub mod all;
     pub mod only;
 }
+pub mod direct;
 pub mod presence;
 pub mod receipt;
 pub mod room;
@@ -142,6 +143,8 @@ pub enum EventType {
     CallHangup,
     /// m.call.invite
     CallInvite,
+    /// m.direct
+    Direct,
     /// m.presence
     Presence,
     /// m.receipt
@@ -243,6 +246,7 @@ impl Display for EventType {
             EventType::CallCandidates => "m.call.candidates",
             EventType::CallHangup => "m.call.hangup",
             EventType::CallInvite => "m.call.invite",
+            EventType::Direct => "m.direct",
             EventType::Presence => "m.presence",
             EventType::Receipt => "m.receipt",
             EventType::RoomAliases => "m.room.aliases",
@@ -275,6 +279,7 @@ impl<'a> From<&'a str> for EventType {
             "m.call.candidates" => EventType::CallCandidates,
             "m.call.hangup" => EventType::CallHangup,
             "m.call.invite" => EventType::CallInvite,
+            "m.direct" => EventType::Direct,
             "m.presence" => EventType::Presence,
             "m.receipt" => EventType::Receipt,
             "m.room.aliases" => EventType::RoomAliases,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -90,6 +90,9 @@ macro_rules! room_event {
             #[serde(rename="type")]
             pub event_type: $crate::EventType,
 
+            /// Timestamp in milliseconds on originating homeserver when this event was sent.
+            pub origin_server_ts: u64,
+
             /// The unique identifier for the room associated with this event.
             pub room_id: ::ruma_identifiers::RoomId,
 
@@ -97,9 +100,8 @@ macro_rules! room_event {
             #[serde(skip_serializing_if="Option::is_none")]
             pub unsigned: Option<::serde_json::Value>,
 
-            /// The unique identifier for the user associated with this event.
-            #[serde(rename="sender")]
-            pub user_id: ::ruma_identifiers::UserId,
+            /// The unique identifier for the user who sent this event.
+            pub sender: ::ruma_identifiers::UserId,
 
             $(
                 $(#[$field_attr])*
@@ -120,6 +122,10 @@ macro_rules! impl_room_event {
                 &self.event_id
             }
 
+            fn origin_server_ts(&self) -> u64 {
+                self.origin_server_ts
+            }
+
             fn room_id(&self) -> &::ruma_identifiers::RoomId {
                 &self.room_id
             }
@@ -128,8 +134,8 @@ macro_rules! impl_room_event {
                 self.unsigned.as_ref()
             }
 
-            fn user_id(&self) -> &::ruma_identifiers::UserId {
-                &self.user_id
+            fn sender(&self) -> &::ruma_identifiers::UserId {
+                &self.sender
             }
         }
     }
@@ -158,6 +164,9 @@ macro_rules! state_event {
             #[serde(rename="type")]
             pub event_type: $crate::EventType,
 
+            /// Timestamp in milliseconds on originating homeserver when this event was sent.
+            pub origin_server_ts: u64,
+
             /// The previous content for this state key, if any.
             #[serde(skip_serializing_if="Option::is_none")]
             pub prev_content: Option<$content_type>,
@@ -173,8 +182,7 @@ macro_rules! state_event {
             pub unsigned: Option<::serde_json::Value>,
 
             /// The unique identifier for the user associated with this event.
-            #[serde(rename="sender")]
-            pub user_id: ::ruma_identifiers::UserId,
+            pub sender: ::ruma_identifiers::UserId,
 
             $(
                 $(#[$field_attr])*

--- a/src/presence.rs
+++ b/src/presence.rs
@@ -25,7 +25,7 @@ pub struct PresenceEventContent {
     #[serde(skip_serializing_if="Option::is_none")]
     pub displayname: Option<String>,
 
-    /// The last time since this used performed some action, in milliseconds.
+    /// The last time since this user performed some action, in milliseconds.
     #[serde(skip_serializing_if="Option::is_none")]
     pub last_active_ago: Option<u64>,
 

--- a/src/room/create.rs
+++ b/src/room/create.rs
@@ -14,5 +14,6 @@ pub struct CreateEventContent {
     /// The `user_id` of the room creator. This is set by the homeserver.
     pub creator: UserId,
     /// Whether or not this room's data should be transferred to other homeservers.
+    #[serde(rename="m.federate")]
     pub federate: Option<bool>,
 }

--- a/src/room/member.rs
+++ b/src/room/member.rs
@@ -38,6 +38,11 @@ pub struct MemberEventContent {
     #[serde(skip_serializing_if="Option::is_none")]
     pub displayname: Option<String>,
 
+    /// Flag indicating if the room containing this event was created
+    /// with the intention of being a direct chat.
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub is_direct: Option<bool>,
+
     /// The membership state of this user.
     pub membership: MembershipState,
 

--- a/src/room/message.rs
+++ b/src/room/message.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde::de::Error;
 use serde_json::{Value, from_value};
 
-use super::ImageInfo;
+use super::{ImageInfo, ThumbnailInfo};
 
 room_event! {
     /// A message sent to a room.
@@ -118,17 +118,13 @@ pub struct FileMessageEventContent {
     /// A human-readable description of the file. This is recommended to be the filename of the
     /// original upload.
     pub body: String,
+    /// The original filename of the uploaded file.
+    pub filename: String,
     /// Metadata about the file referred to in `url`.
     #[serde(skip_serializing_if="Option::is_none")]
     pub info: Option<FileInfo>,
     /// The message type. Always *m.file*.
     pub msgtype: MessageType,
-    /// Metadata about the image referred to in `thumbnail_url`.
-    #[serde(skip_serializing_if="Option::is_none")]
-    pub thumbnail_info: Option<ImageInfo>,
-    /// The URL to the thumbnail of the file.
-    #[serde(skip_serializing_if="Option::is_none")]
-    pub thumbnail_url: Option<String>,
     /// The URL to the file.
     pub url: String,
 }
@@ -140,6 +136,12 @@ pub struct FileInfo {
     pub mimetype: String,
     /// The size of the file in bytes.
     pub size: u64,
+    /// Metadata about the image referred to in `thumbnail_url`.
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub thumbnail_info: Option<ThumbnailInfo>,
+    /// The URL to the thumbnail of the file.
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub thumbnail_url: Option<String>,
 }
 
 /// The payload of an image message.
@@ -153,12 +155,6 @@ pub struct ImageMessageEventContent {
     pub info: Option<ImageInfo>,
     /// The message type. Always *m.image*.
     pub msgtype: MessageType,
-    /// Metadata about the image referred to in `thumbnail_url`.
-    #[serde(skip_serializing_if="Option::is_none")]
-    pub thumbnail_info: Option<ImageInfo>,
-    /// The URL to the thumbnail of the image.
-    #[serde(skip_serializing_if="Option::is_none")]
-    pub thumbnail_url: Option<String>,
     /// The URL to the image.
     pub url: String,
 }
@@ -173,9 +169,17 @@ pub struct LocationMessageEventContent {
     pub geo_uri: String,
     /// The message type. Always *m.location*.
     pub msgtype: MessageType,
+    /// Info about the location being represented.
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub info: Option<LocationInfo>,
+}
+
+/// Thumbnail info associated with a location.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct LocationInfo {
     /// Metadata about the image referred to in `thumbnail_url`.
     #[serde(skip_serializing_if="Option::is_none")]
-    pub thumbnail_info: Option<ImageInfo>,
+    pub thumbnail_info: Option<ThumbnailInfo>,
     /// The URL to a thumbnail of the location being represented.
     #[serde(skip_serializing_if="Option::is_none")]
     pub thumbnail_url: Option<String>,
@@ -232,7 +236,7 @@ pub struct VideoInfo {
     pub size: Option<u64>,
     /// Metadata about an image.
     #[serde(skip_serializing_if="Option::is_none")]
-    pub thumbnail_info: Option<ImageInfo>,
+    pub thumbnail_info: Option<ThumbnailInfo>,
     /// The URL to a thumbnail of the video clip.
     #[serde(skip_serializing_if="Option::is_none")]
     pub thumbnail_url: Option<String>,

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -12,6 +12,7 @@ pub mod join_rules;
 pub mod member;
 pub mod message;
 pub mod name;
+pub mod pinned_events;
 pub mod power_levels;
 pub mod redaction;
 pub mod third_party_invite;

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -21,13 +21,34 @@ pub mod topic;
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ImageInfo {
     /// The height of the image in pixels.
-    #[serde(rename = "h")]
+    #[serde(rename="h")]
     pub height: u64,
     /// The MIME type of the image, e.g. "image/png."
     pub mimetype: String,
     /// The file size of the image in bytes.
     pub size: u64,
+    /// Metadata about the image referred to in `thumbnail_url`.
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub thumbnail_info: Option<ThumbnailInfo>,
+    /// The URL to the thumbnail of the image.
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub thumbnail_url: Option<String>,
     /// The width of the image in pixels.
-    #[serde(rename = "w")]
+    #[serde(rename="w")]
+    pub width: u64,
+}
+
+/// Metadata about a thumbnail.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct ThumbnailInfo {
+    /// The height of the thumbnail in pixels.
+    #[serde(rename="h")]
+    pub height: u64,
+    /// The MIME type of the thumbnail, e.g. "image/png."
+    pub mimetype: String,
+    /// The file size of the thumbnail in bytes.
+    pub size: u64,
+    /// The width of the thumbnail in pixels.
+    #[serde(rename="w")]
     pub width: u64,
 }

--- a/src/room/pinned_events.rs
+++ b/src/room/pinned_events.rs
@@ -1,0 +1,63 @@
+//! Types for the *m.room.pinned_events* event.
+
+use ruma_identifiers::EventId;
+
+state_event! {
+    /// Used to "pin" particular events in a room for other participants to review later.
+    pub struct PinnedEventsEvent(PinnedEventsContent) {}
+}
+
+/// The payload of a `NameEvent`.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct PinnedEventsContent {
+    /// An ordered list of event IDs to pin.
+    pub pinned: Vec<EventId>,
+}
+
+#[cfg(test)]
+mod tests {
+    use ruma_identifiers::{EventId, RoomId, UserId};
+    use serde_json::{from_str, to_string};
+
+    use Event;
+    use EventType;
+    use RoomEvent;
+    use StateEvent;
+    use room::pinned_events::{PinnedEventsEvent, PinnedEventsContent};
+
+    #[test]
+    fn serialization_deserialization() {
+        let mut content: PinnedEventsContent = PinnedEventsContent {
+            pinned: Vec::new()
+        };
+
+        content.pinned.push(EventId::new("example.com").unwrap());
+        content.pinned.push(EventId::new("example.com").unwrap());
+
+        let event = PinnedEventsEvent {
+            content: content.clone(),
+            event_id: EventId::new("example.com").unwrap(),
+            event_type: EventType::RoomPinnedEvents,
+            origin_server_ts: 1432804485886,
+            prev_content: None,
+            room_id: RoomId::new("example.com").unwrap(),
+            sender: UserId::new("example.com").unwrap(),
+            state_key: "".to_string(),
+            unsigned: None,
+        };
+
+        let serialized_event = to_string(&event).unwrap();
+        let parsed_event: PinnedEventsEvent = from_str(&serialized_event).unwrap();
+
+        assert_eq!(parsed_event.event_id(), event.event_id());
+        assert_eq!(parsed_event.room_id(), event.room_id());
+        assert_eq!(parsed_event.sender(), event.sender());
+        assert_eq!(parsed_event.unsigned(), event.unsigned());
+        assert_eq!(parsed_event.state_key(), event.state_key());
+        assert_eq!(parsed_event.origin_server_ts(), event.origin_server_ts());
+
+        assert_eq!(parsed_event.content().pinned, event.content.pinned);
+        assert_eq!(parsed_event.content().pinned[0], content.pinned[0]);
+        assert_eq!(parsed_event.content().pinned[1], content.pinned[1]);
+    }
+}

--- a/src/stripped.rs
+++ b/src/stripped.rs
@@ -294,7 +294,14 @@ mod tests {
                     "h": 128,
                     "w": 128,
                     "mimetype": "image/jpeg",
-                    "size": 1024
+                    "size": 1024,
+                    "thumbnail_info": {
+                        "h": 16,
+                        "w": 16,
+                        "mimetype": "image/jpeg",
+                        "size": 32
+                    },
+                    "thumbnail_url": "https://domain.com/image-thumbnail.jpg"
                 },
                 "thumbnail_info": {
                     "h": 16,

--- a/src/typing.rs
+++ b/src/typing.rs
@@ -1,6 +1,6 @@
 //! Types for the *m.typing* event.
 
-use ruma_identifiers::{EventId, RoomId};
+use ruma_identifiers::{RoomId, UserId};
 
 event! {
     /// Informs the client of the list of users currently typing.
@@ -14,5 +14,5 @@ event! {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct TypingEventContent {
     /// The list of user IDs typing in this room, if any.
-    pub user_ids: Vec<EventId>,
+    pub user_ids: Vec<UserId>,
 }


### PR DESCRIPTION
A work in progress so we can integrate the latest changes. 

So far it matches the [HEAD](https://matrix.org/speculator/spec/HEAD/client_server/unstable.html) of the spec with the exception of the [new](https://matrix.org/speculator/spec/HEAD/client_server/unstable.html#m-direct) event `m.direct`. It will be updated (if any change occurs) until `v0.3.0` comes out.