### PR TITLE
Make the federate field optional

### DIFF
--- a/src/room/create.rs
+++ b/src/room/create.rs
@@ -14,5 +14,5 @@ pub struct CreateEventContent {
     /// The `user_id` of the room creator. This is set by the homeserver.
     pub creator: UserId,
     /// Whether or not this room's data should be transferred to other homeservers.
-    pub federate: bool,
+    pub federate: Option<bool>,
 }


### PR DESCRIPTION
According to the spec the field is optional: http://matrix.org/docs/spec/client_server/r0.2.0.html#m-room-create