### PR TITLE
Power level defaults

### DIFF
--- a/src/room/power_levels.rs
+++ b/src/room/power_levels.rs
@@ -15,6 +15,7 @@ state_event! {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct PowerLevelsEventContent {
     /// The level required to ban a user.
+    #[serde(default="default_power_level")]
     pub ban: u64,
 
     /// The level required to send specific event types.
@@ -23,18 +24,23 @@ pub struct PowerLevelsEventContent {
     pub events: HashMap<EventType, u64>,
 
     /// The default level required to send message events.
+    #[serde(default)]
     pub events_default: u64,
 
     /// The level required to invite a user.
+    #[serde(default="default_power_level")]
     pub invite: u64,
 
     /// The level required to kick a user.
+    #[serde(default="default_power_level")]
     pub kick: u64,
 
     /// The level required to redact an event.
+    #[serde(default="default_power_level")]
     pub redact: u64,
 
     /// The default level required to send state events.
+    #[serde(default="default_power_level")]
     pub state_default: u64,
 
     /// The power levels for specific users.
@@ -43,5 +49,10 @@ pub struct PowerLevelsEventContent {
     pub users: HashMap<UserId, u64>,
 
     /// The default power level for every user in the room.
+    #[serde(default)]
     pub users_default: u64,
+}
+
+fn default_power_level() -> u64 {
+    50
 }


### PR DESCRIPTION
http://matrix.org/docs/spec/client_server/r0.2.0.html#m-room-power-levels describes three fields that have default values if they are not specified, this PR adds those default values.