### PR TITLE
Use ruma-signatures 0.4 instead of 0.3.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ version = "0.8.0"
 
 [dependencies]
 ruma-identifiers = "0.11"
-ruma-signatures = "0.3"
+ruma-signatures = "0.4"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"


### PR DESCRIPTION
This should fix build issues since ruma-signatures links to ring 0.7, which is not availible anymore.