### PR TITLE
More bytesize fixes

### DIFF
--- a/src/call/candidates.rs
+++ b/src/call/candidates.rs
@@ -24,7 +24,9 @@ pub struct Candidate {
     /// The SDP "a" line of the candidate.
     pub candidate: String,
     /// The SDP media type this candidate is intended for.
+    #[serde(rename = "sdpMid")]
     pub sdp_mid: String,
     /// The index of the SDP "m" line this candidate is intended for.
+    #[serde(rename = "sdpMLineIndex")]
     pub sdp_m_line_index: u64,
 }

--- a/src/call/mod.rs
+++ b/src/call/mod.rs
@@ -11,6 +11,7 @@ pub mod invite;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SessionDescription {
     /// The type of session description.
+    #[serde(rename="type")]
     pub session_type: SessionDescriptionType,
     /// The SDP text of the session description.
     pub sdp: String,

--- a/src/presence.rs
+++ b/src/presence.rs
@@ -18,6 +18,7 @@ pub struct PresenceEventContent {
     pub avatar_url: Option<String>,
 
     /// Whether or not the user is currently active.
+    #[serde(skip_serializing_if="Option::is_none")]
     pub currently_active: Option<bool>,
 
     /// The current display name for this user.

--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -23,6 +23,7 @@ pub type ReceiptEventContent = HashMap<EventId, Receipts>;
 pub struct Receipts {
     /// A collection of users who have sent *m.read* receipts for this event.
     #[serde(rename="m.read")]
+    #[serde(default)]
     pub m_read: UserReceipts,
 }
 

--- a/src/room/avatar.rs
+++ b/src/room/avatar.rs
@@ -13,11 +13,14 @@ state_event! {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AvatarEventContent {
     /// Information about the avatar image.
-    pub info: ImageInfo,
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub info: Option<ImageInfo>,
     /// Information about the avatar thumbnail image.
-    pub thumbnail_info: ImageInfo,
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub thumbnail_info: Option<ImageInfo>,
     /// URL of the avatar thumbnail image.
-    pub thumbnail_url: String,
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub thumbnail_url: Option<String>,
     /// URL of the avatar image.
     pub url: String,
 }

--- a/src/room/message.rs
+++ b/src/room/message.rs
@@ -56,22 +56,22 @@ pub enum MessageEventContent {
     /// An emote message.
     Emote(EmoteMessageEventContent),
 
-    /// An file message.
+    /// A file message.
     File(FileMessageEventContent),
 
     /// An image message.
     Image(ImageMessageEventContent),
 
-    /// An location message.
+    /// A location message.
     Location(LocationMessageEventContent),
 
-    /// An notice message.
+    /// A notice message.
     Notice(NoticeMessageEventContent),
 
     /// An text message.
     Text(TextMessageEventContent),
 
-    /// An video message.
+    /// A video message.
     Video(VideoMessageEventContent),
 }
 

--- a/src/room/message.rs
+++ b/src/room/message.rs
@@ -221,8 +221,9 @@ pub struct VideoInfo {
     #[serde(skip_serializing_if="Option::is_none")]
     pub duration: Option<u64>,
     /// The height of the video in pixels.
+    #[serde(rename = "h")]
     #[serde(skip_serializing_if="Option::is_none")]
-    pub h: Option<u64>,
+    pub height: Option<u64>,
     /// The mimetype of the video, e.g. "video/mp4."
     #[serde(skip_serializing_if="Option::is_none")]
     pub mimetype: Option<String>,
@@ -236,8 +237,9 @@ pub struct VideoInfo {
     #[serde(skip_serializing_if="Option::is_none")]
     pub thumbnail_url: Option<String>,
     /// The width of the video in pixels.
+    #[serde(rename = "w")]
     #[serde(skip_serializing_if="Option::is_none")]
-    pub w: Option<u64>,
+    pub width: Option<u64>,
 }
 
 impl_enum! {

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -21,11 +21,11 @@ pub mod topic;
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ImageInfo {
     /// The height of the image in pixels.
-    pub height: u64,
+    pub h: u64,
     /// The MIME type of the image, e.g. "image/png."
     pub mimetype: String,
     /// The file size of the image in bytes.
     pub size: u64,
     /// The width of the image in pixels.
-    pub width: u64,
+    pub w: u64,
 }

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -21,11 +21,13 @@ pub mod topic;
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ImageInfo {
     /// The height of the image in pixels.
-    pub h: u64,
+    #[serde(rename = "h")]
+    pub height: u64,
     /// The MIME type of the image, e.g. "image/png."
     pub mimetype: String,
     /// The file size of the image in bytes.
     pub size: u64,
     /// The width of the image in pixels.
-    pub w: u64,
+    #[serde(rename = "w")]
+    pub width: u64,
 }

--- a/src/stripped.rs
+++ b/src/stripped.rs
@@ -333,8 +333,8 @@ mod tests {
             StrippedState::RoomAvatar(event) => {
                 let image_info = event.content.info.unwrap();
 
-                assert_eq!(image_info.h, 128);
-                assert_eq!(image_info.w, 128);
+                assert_eq!(image_info.height, 128);
+                assert_eq!(image_info.width, 128);
                 assert_eq!(image_info.mimetype, "image/jpeg");
                 assert_eq!(image_info.size, 1024);
                 assert_eq!(event.content.thumbnail_info.unwrap().size, 32);

--- a/src/stripped.rs
+++ b/src/stripped.rs
@@ -291,14 +291,14 @@ mod tests {
             "state_key": "",
             "content": {
                 "info": {
-                    "height": 128,
-                    "width": 128,
+                    "h": 128,
+                    "w": 128,
                     "mimetype": "image/jpeg",
                     "size": 1024
                 },
                 "thumbnail_info": {
-                    "height": 16,
-                    "width": 16,
+                    "h": 16,
+                    "w": 16,
                     "mimetype": "image/jpeg",
                     "size": 32
                 },
@@ -331,11 +331,13 @@ mod tests {
 
         match from_str::<StrippedState>(avatar_event).unwrap() {
             StrippedState::RoomAvatar(event) => {
-                assert_eq!(event.content.info.height, 128);
-                assert_eq!(event.content.info.width, 128);
-                assert_eq!(event.content.info.mimetype, "image/jpeg");
-                assert_eq!(event.content.info.size, 1024);
-                assert_eq!(event.content.thumbnail_info.size, 32);
+                let image_info = event.content.info.unwrap();
+
+                assert_eq!(image_info.h, 128);
+                assert_eq!(image_info.w, 128);
+                assert_eq!(image_info.mimetype, "image/jpeg");
+                assert_eq!(image_info.size, 1024);
+                assert_eq!(event.content.thumbnail_info.unwrap().size, 32);
                 assert_eq!(event.content.url, "https://domain.com/image.jpg");
                 assert_eq!(event.event_type, EventType::RoomAvatar);
                 assert_eq!(event.state_key, "");


### PR DESCRIPTION
Links to relevant spec parts:

* `m.call.*`: https://matrix.org/docs/spec/client_server/r0.2.0.html#voice-over-ip
* `m.receipt`: https://matrix.org/docs/spec/client_server/r0.2.0.html#m-receipt
* `m.room.avatar`: https://matrix.org/docs/spec/client_server/r0.2.0.html#m-room-avatar