### PR TITLE
Fix typing notification content struct

### DIFF
--- a/src/typing.rs
+++ b/src/typing.rs
@@ -1,6 +1,6 @@
 //! Types for the *m.typing* event.
 
-use ruma_identifiers::{EventId, RoomId};
+use ruma_identifiers::{UserId, RoomId};
 
 event! {
     /// Informs the client of the list of users currently typing.
@@ -14,5 +14,5 @@ event! {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct TypingEventContent {
     /// The list of user IDs typing in this room, if any.
-    pub user_ids: Vec<EventId>,
+    pub user_ids: Vec<UserId>,
 }


### PR DESCRIPTION
The spec only indicates that this field should be a string, but makes clear in the description and example that the content should be a full user ID, not an event ID. This PR fixes the struct so it can deserialize properly.