### PR TITLE
Replace serde_derive by re-exports in serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ edition = "2018"
 [dependencies]
 ruma-identifiers = "0.11.0"
 ruma-signatures = "0.4.1"
-serde = "1.0.80"
-serde_derive = "1.0.80"
-serde_json = "1.0.33"
+serde_json = "1.0.38"
+
+[dependencies.serde]
+version = "1.0.87"
+features = ["derive"]

--- a/src/call/answer.rs
+++ b/src/call/answer.rs
@@ -1,6 +1,6 @@
 //! Types for the *m.call.answer* event.
 
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use super::SessionDescription;
 

--- a/src/call/candidates.rs
+++ b/src/call/candidates.rs
@@ -1,6 +1,6 @@
 //! Types for the *m.call.candidates* event.
 
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 room_event! {
     /// This event is sent by callers after sending an invite and by the callee after answering.

--- a/src/call/hangup.rs
+++ b/src/call/hangup.rs
@@ -1,6 +1,6 @@
 //! Types for the *m.call.hangup* event.
 
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 room_event! {
     /// Sent by either party to signal their termination of the call. This can be sent either once

--- a/src/call/invite.rs
+++ b/src/call/invite.rs
@@ -1,6 +1,6 @@
 //! Types for the *m.call.invite* event.
 
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use super::SessionDescription;
 

--- a/src/call/mod.rs
+++ b/src/call/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! This module also contains types shared by events in its child namespaces.
 
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 pub mod answer;
 pub mod candidates;

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 
 use ruma_identifiers::{RoomId, UserId};
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 event! {
     /// Informs the client about the rooms that are considered direct by a user.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,6 @@ use serde::{
     de::{Error as SerdeError, Visitor},
     Deserialize, Deserializer, Serialize, Serializer,
 };
-use serde_derive::{Deserialize, Serialize};
 use serde_json::Value;
 
 #[macro_use]

--- a/src/presence.rs
+++ b/src/presence.rs
@@ -1,6 +1,6 @@
 //! Types for the *m.presence* event.
 
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use ruma_identifiers::UserId;
 

--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 
 use ruma_identifiers::{EventId, RoomId, UserId};
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 event! {
     /// Informs the client of new receipts.

--- a/src/room/aliases.rs
+++ b/src/room/aliases.rs
@@ -1,7 +1,7 @@
 //! Types for the *m.room.aliases* event.
 
 use ruma_identifiers::RoomAliasId;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 state_event! {
     /// Informs the room about what room aliases it has been given.

--- a/src/room/avatar.rs
+++ b/src/room/avatar.rs
@@ -1,6 +1,6 @@
 //! Types for the *m.room.avatar* event.
 
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use super::ImageInfo;
 

--- a/src/room/canonical_alias.rs
+++ b/src/room/canonical_alias.rs
@@ -1,7 +1,7 @@
 //! Types for the *m.room.canonical_alias* event.
 
 use ruma_identifiers::RoomAliasId;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 state_event! {
     /// Informs the room as to which alias is the canonical one.

--- a/src/room/create.rs
+++ b/src/room/create.rs
@@ -1,7 +1,7 @@
 //! Types for the *m.room.create* event.
 
 use ruma_identifiers::UserId;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 state_event! {
     /// This is the first event in a room and cannot be changed. It acts as the root of all other

--- a/src/room/guest_access.rs
+++ b/src/room/guest_access.rs
@@ -1,6 +1,6 @@
 //! Types for the *m.room.guest_access* event.
 
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 state_event! {
     /// Controls whether guest users are allowed to join rooms.

--- a/src/room/history_visibility.rs
+++ b/src/room/history_visibility.rs
@@ -1,6 +1,6 @@
 //! Types for the *m.room.history_visibility* event.
 
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 state_event! {
     /// This event controls whether a member of a room can see the events that happened in a room

--- a/src/room/join_rules.rs
+++ b/src/room/join_rules.rs
@@ -1,6 +1,6 @@
 //! Types for the *m.room.join_rules* event.
 
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 state_event! {
     /// Describes how users are allowed to join the room.

--- a/src/room/member.rs
+++ b/src/room/member.rs
@@ -2,7 +2,7 @@
 
 use ruma_identifiers::UserId;
 use ruma_signatures::Signatures;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use crate::stripped::StrippedState;
 

--- a/src/room/message.rs
+++ b/src/room/message.rs
@@ -1,7 +1,6 @@
 //! Types for the *m.room.message* event.
 
 use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
-use serde_derive::{Deserialize, Serialize};
 use serde_json::{from_value, Value};
 
 use super::{ImageInfo, ThumbnailInfo};

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! This module also contains types shared by events in its child namespaces.
 
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 pub mod aliases;
 pub mod avatar;

--- a/src/room/name.rs
+++ b/src/room/name.rs
@@ -1,6 +1,6 @@
 //! Types for the *m.room.name* event.
 
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 state_event! {
     /// A human-friendly room name designed to be displayed to the end-user.

--- a/src/room/pinned_events.rs
+++ b/src/room/pinned_events.rs
@@ -1,7 +1,7 @@
 //! Types for the *m.room.pinned_events* event.
 
 use ruma_identifiers::EventId;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 state_event! {
     /// Used to "pin" particular events in a room for other participants to review later.

--- a/src/room/power_levels.rs
+++ b/src/room/power_levels.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 
 use ruma_identifiers::UserId;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use crate::EventType;
 

--- a/src/room/redaction.rs
+++ b/src/room/redaction.rs
@@ -1,7 +1,7 @@
 //! Types for the *m.room.redaction* event.
 
 use ruma_identifiers::EventId;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 room_event! {
     /// A redaction of an event.

--- a/src/room/third_party_invite.rs
+++ b/src/room/third_party_invite.rs
@@ -1,6 +1,6 @@
 //! Types for the *m.room.third_party_invite* event.
 
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 state_event! {
     /// An invitation to a room issued to a third party identifier, rather than a matrix user ID.

--- a/src/room/topic.rs
+++ b/src/room/topic.rs
@@ -1,6 +1,6 @@
 //! Types for the *m.room.topic* event.
 
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 state_event! {
     /// A topic is a short message detailing what is currently being discussed in the room.

--- a/src/stripped.rs
+++ b/src/stripped.rs
@@ -7,7 +7,6 @@
 
 use ruma_identifiers::UserId;
 use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
-use serde_derive::{Deserialize, Serialize};
 use serde_json::{from_value, Value};
 
 use crate::{

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 event! {
     /// Informs the client of tags on a room.

--- a/src/typing.rs
+++ b/src/typing.rs
@@ -1,7 +1,7 @@
 //! Types for the *m.typing* event.
 
 use ruma_identifiers::{RoomId, UserId};
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 event! {
     /// Informs the client of the list of users currently typing.


### PR DESCRIPTION
This prevents issues when using this crate together with another one that also enables this feature (which currently results in duplicate imports).