### PR TITLE
Fix missing "m." in serialization of the "m.relates_to" key

### DIFF
--- a/src/room/message.rs
+++ b/src/room/message.rs
@@ -1065,9 +1065,7 @@ mod tests {
             formatted_body: None,
             relates_to: Some(RelatesTo {
                 in_reply_to: InReplyTo {
-                    event_id: EventId::try_from("$15827405538098VGFWH:example.com")
-                        .unwrap()
-                        .to_owned(),
+                    event_id: EventId::try_from("$15827405538098VGFWH:example.com").unwrap(),
                 },
             }),
         });

--- a/src/room/message.rs
+++ b/src/room/message.rs
@@ -1038,6 +1038,9 @@ mod tests {
 
     use super::{AudioMessageEventContent, MessageEventContent};
     use crate::EventResult;
+    use crate::room::message::{TextMessageEventContent, RelatesTo, InReplyTo};
+    use ruma_identifiers::EventId;
+    use std::convert::TryFrom;
 
     #[test]
     fn serialization() {
@@ -1051,6 +1054,25 @@ mod tests {
         assert_eq!(
             to_string(&message_event_content).unwrap(),
             r#"{"body":"test","msgtype":"m.audio","url":"http://example.com/audio.mp3"}"#
+        );
+    }
+
+    #[test]
+    fn relates_to_serialization() {
+        let message_event_content = MessageEventContent::Text(TextMessageEventContent {
+            body: "> <@test:example.com> test\n\ntest reply".to_owned(),
+            format: None,
+            formatted_body: None,
+            relates_to: Some(RelatesTo {
+                in_reply_to: InReplyTo {
+                    event_id: EventId::try_from("$15827405538098VGFWH:example.com").unwrap().to_owned(),
+                },
+            }),
+        });
+
+        assert_eq!(
+            to_string(&message_event_content).unwrap(),
+            r#"{"body":"> <@test:example.com> test\n\ntest reply","msgtype":"m.text","m.relates_to":{"m.in_reply_to":{"event_id":"$15827405538098VGFWH:example.com"}}}"#
         );
     }
 

--- a/src/room/message.rs
+++ b/src/room/message.rs
@@ -911,7 +911,7 @@ impl Serialize for NoticeMessageEventContent {
         state.serialize_field("msgtype", "m.notice")?;
 
         if self.relates_to.is_some() {
-            state.serialize_field("relates_to", &self.relates_to)?;
+            state.serialize_field("m.relates_to", &self.relates_to)?;
         }
 
         state.end()
@@ -985,7 +985,7 @@ impl Serialize for TextMessageEventContent {
         state.serialize_field("msgtype", "m.text")?;
 
         if self.relates_to.is_some() {
-            state.serialize_field("relates_to", &self.relates_to)?;
+            state.serialize_field("m.relates_to", &self.relates_to)?;
         }
 
         state.end()

--- a/src/room/message.rs
+++ b/src/room/message.rs
@@ -1037,8 +1037,8 @@ mod tests {
     use serde_json::to_string;
 
     use super::{AudioMessageEventContent, MessageEventContent};
+    use crate::room::message::{InReplyTo, RelatesTo, TextMessageEventContent};
     use crate::EventResult;
-    use crate::room::message::{TextMessageEventContent, RelatesTo, InReplyTo};
     use ruma_identifiers::EventId;
     use std::convert::TryFrom;
 
@@ -1065,7 +1065,9 @@ mod tests {
             formatted_body: None,
             relates_to: Some(RelatesTo {
                 in_reply_to: InReplyTo {
-                    event_id: EventId::try_from("$15827405538098VGFWH:example.com").unwrap().to_owned(),
+                    event_id: EventId::try_from("$15827405538098VGFWH:example.com")
+                        .unwrap()
+                        .to_owned(),
                 },
             }),
         });


### PR DESCRIPTION
This PR fixes that "m.relates_to" is correctly serialized.

Before:
```
 {
    "body": "> <@MTRNord:matrix.ffslfl.net> !test\n\ntest resp",
    "msgtype": "m.notice",
    "relates_to": {
      "m.in_reply_to": {
        "event_id": "$15827405538098VGFWH:matrix.ffslfl.net"
      }
    }
  }
```

After:
```
 {
    "body": "> <@MTRNord:matrix.ffslfl.net> !test\n\ntest resp",
    "msgtype": "m.notice",
    "m.relates_to": {
      "m.in_reply_to": {
        "event_id": "$15827405538098VGFWH:matrix.ffslfl.net"
      }
    }
  }
```

This is according to https://matrix.org/docs/spec/client_server/r0.5.0#rich-replies

This PR also adds a small test to prevent a regression of this issue.