### PR TITLE
Rewrite tests to use `serde_json::json!` instead of raw strings

### DIFF
--- a/src/direct.rs
+++ b/src/direct.rs
@@ -25,7 +25,9 @@ mod tests {
     use std::collections::HashMap;
 
     use ruma_identifiers::{RoomId, UserId};
-    use serde_json::{from_value, json, to_value};
+    use serde_json::from_value as from_json_value;
+    use serde_json::json;
+    use serde_json::to_value as to_json_value;
 
     use super::{DirectEvent, DirectEventContent};
     use crate::EventResult;
@@ -46,7 +48,7 @@ mod tests {
             "type": "m.direct"
         });
 
-        assert_eq!(to_value(&event).unwrap(), json_data);
+        assert_eq!(to_json_value(&event).unwrap(), json_data);
     }
 
     #[test]
@@ -64,7 +66,7 @@ mod tests {
             "type": "m.direct"
         });
 
-        let event: DirectEvent = from_value::<EventResult<_>>(json_data)
+        let event: DirectEvent = from_json_value::<EventResult<_>>(json_data)
             .unwrap()
             .into_result()
             .unwrap();

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -25,9 +25,7 @@ mod tests {
     use std::collections::HashMap;
 
     use ruma_identifiers::{RoomId, UserId};
-    use serde_json::from_value as from_json_value;
-    use serde_json::json;
-    use serde_json::to_value as to_json_value;
+    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
     use super::{DirectEvent, DirectEventContent};
     use crate::EventResult;

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -25,7 +25,7 @@ mod tests {
     use std::collections::HashMap;
 
     use ruma_identifiers::{RoomId, UserId};
-    use serde_json::to_string;
+    use serde_json::{from_value, json, to_value};
 
     use super::{DirectEvent, DirectEventContent};
     use crate::EventResult;
@@ -39,15 +39,14 @@ mod tests {
         content.insert(alice.clone(), room.clone());
 
         let event = DirectEvent { content };
+        let json_data = json! ({
+            "content": {
+                alice.to_string(): vec![room[0].to_string()],
+            },
+            "type": "m.direct"
+        });
 
-        assert_eq!(
-            to_string(&event).unwrap(),
-            format!(
-                r#"{{"content":{{"{}":["{}"]}},"type":"m.direct"}}"#,
-                alice.to_string(),
-                room[0].to_string()
-            )
-        );
+        assert_eq!(to_value(&event).unwrap(), json_data);
     }
 
     #[test]
@@ -58,17 +57,14 @@ mod tests {
             RoomId::new("ruma.io").unwrap(),
         ];
 
-        let json_data = format!(
-            r#"{{
-            "content": {{ "{}": ["{}", "{}"] }},
+        let json_data = json! ({
+            "content": {
+                alice.to_string(): vec![rooms[0].to_string(), rooms[1].to_string()],
+            },
             "type": "m.direct"
-        }}"#,
-            alice.to_string(),
-            rooms[0].to_string(),
-            rooms[1].to_string()
-        );
+        });
 
-        let event: DirectEvent = serde_json::from_str::<EventResult<_>>(&json_data)
+        let event: DirectEvent = from_value::<EventResult<_>>(json_data)
             .unwrap()
             .into_result()
             .unwrap();

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -39,7 +39,7 @@ mod tests {
         content.insert(alice.clone(), room.clone());
 
         let event = DirectEvent { content };
-        let json_data = json! ({
+        let json_data = json!({
             "content": {
                 alice.to_string(): vec![room[0].to_string()],
             },
@@ -57,7 +57,7 @@ mod tests {
             RoomId::new("ruma.io").unwrap(),
         ];
 
-        let json_data = json! ({
+        let json_data = json!({
             "content": {
                 alice.to_string(): vec![rooms[0].to_string(), rooms[1].to_string()],
             },

--- a/src/dummy.rs
+++ b/src/dummy.rs
@@ -29,9 +29,7 @@ mod tests {
     use super::{DummyEvent, Empty};
     use crate::EventResult;
 
-    use serde_json::from_value as from_json_value;
-    use serde_json::json;
-    use serde_json::to_value as to_json_value;
+    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
     #[test]
     fn serialization() {

--- a/src/dummy.rs
+++ b/src/dummy.rs
@@ -29,21 +29,29 @@ mod tests {
     use super::{DummyEvent, Empty};
     use crate::EventResult;
 
+    use serde_json::{json, to_value};
+
     #[test]
     fn serialization() {
         let dummy_event = DummyEvent { content: Empty };
+        let actual = to_value(dummy_event).unwrap();
 
-        let actual = serde_json::to_string(&dummy_event).unwrap();
-        let expected = r#"{"content":{},"type":"m.dummy"}"#;
+        let expected = json!({
+            "content": {},
+            "type": "m.dummy"
+        });
 
         assert_eq!(actual, expected);
     }
 
     #[test]
     fn deserialization() {
-        let json = r#"{"content":{},"type":"m.dummy"}"#;
+        let json = json!({
+            "content": {},
+            "type": "m.dummy"
+        });
 
-        assert!(serde_json::from_str::<EventResult<DummyEvent>>(json)
+        assert!(serde_json::from_value::<EventResult<DummyEvent>>(json)
             .unwrap()
             .into_result()
             .is_ok());

--- a/src/dummy.rs
+++ b/src/dummy.rs
@@ -29,7 +29,7 @@ mod tests {
     use super::{DummyEvent, Empty};
     use crate::EventResult;
 
-    use serde_json::{json, to_value};
+    use serde_json::{from_value, json, to_value};
 
     #[test]
     fn serialization() {
@@ -51,7 +51,7 @@ mod tests {
             "type": "m.dummy"
         });
 
-        assert!(serde_json::from_value::<EventResult<DummyEvent>>(json)
+        assert!(from_value::<EventResult<DummyEvent>>(json)
             .unwrap()
             .into_result()
             .is_ok());

--- a/src/dummy.rs
+++ b/src/dummy.rs
@@ -29,12 +29,14 @@ mod tests {
     use super::{DummyEvent, Empty};
     use crate::EventResult;
 
-    use serde_json::{from_value, json, to_value};
+    use serde_json::from_value as from_json_value;
+    use serde_json::json;
+    use serde_json::to_value as to_json_value;
 
     #[test]
     fn serialization() {
         let dummy_event = DummyEvent { content: Empty };
-        let actual = to_value(dummy_event).unwrap();
+        let actual = to_json_value(dummy_event).unwrap();
 
         let expected = json!({
             "content": {},
@@ -51,7 +53,7 @@ mod tests {
             "type": "m.dummy"
         });
 
-        assert!(from_value::<EventResult<DummyEvent>>(json)
+        assert!(from_json_value::<EventResult<DummyEvent>>(json)
             .unwrap()
             .into_result()
             .is_ok());

--- a/src/ignored_user_list.rs
+++ b/src/ignored_user_list.rs
@@ -84,9 +84,7 @@ mod tests {
     use std::convert::TryFrom;
 
     use ruma_identifiers::UserId;
-    use serde_json::from_value as from_json_value;
-    use serde_json::json;
-    use serde_json::to_value as to_json_value;
+    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
     use super::{IgnoredUserListEvent, IgnoredUserListEventContent};
     use crate::EventResult;

--- a/src/ignored_user_list.rs
+++ b/src/ignored_user_list.rs
@@ -84,6 +84,7 @@ mod tests {
     use std::convert::TryFrom;
 
     use ruma_identifiers::UserId;
+    use serde_json::{from_value, json, to_value};
 
     use super::{IgnoredUserListEvent, IgnoredUserListEventContent};
     use crate::EventResult;
@@ -96,19 +97,30 @@ mod tests {
             },
         };
 
-        let json = serde_json::to_string(&ignored_user_list_event).unwrap();
+        let json_data = json!({
+            "content": {
+                "ignored_users": {
+                    "@carl:example.com":{}
+                }
+            },
+            "type":"m.ignored_user_list"
+        });
 
-        assert_eq!(
-            json,
-            r#"{"content":{"ignored_users":{"@carl:example.com":{}}},"type":"m.ignored_user_list"}"#
-        );
+        assert_eq!(to_value(ignored_user_list_event).unwrap(), json_data);
     }
 
     #[test]
     fn deserialization() {
-        let json = r#"{"content":{"ignored_users":{"@carl:example.com":{}}},"type":"m.ignored_user_list"}"#;
+        let json_data = json!({
+            "content": {
+                "ignored_users": {
+                    "@carl:example.com":{}
+                }
+            },
+            "type":"m.ignored_user_list"
+        });
 
-        let actual = serde_json::from_str::<EventResult<IgnoredUserListEvent>>(json)
+        let actual = from_value::<EventResult<IgnoredUserListEvent>>(json_data)
             .unwrap()
             .into_result()
             .unwrap();

--- a/src/ignored_user_list.rs
+++ b/src/ignored_user_list.rs
@@ -84,7 +84,9 @@ mod tests {
     use std::convert::TryFrom;
 
     use ruma_identifiers::UserId;
-    use serde_json::{from_value, json, to_value};
+    use serde_json::from_value as from_json_value;
+    use serde_json::json;
+    use serde_json::to_value as to_json_value;
 
     use super::{IgnoredUserListEvent, IgnoredUserListEventContent};
     use crate::EventResult;
@@ -106,7 +108,7 @@ mod tests {
             "type":"m.ignored_user_list"
         });
 
-        assert_eq!(to_value(ignored_user_list_event).unwrap(), json_data);
+        assert_eq!(to_json_value(ignored_user_list_event).unwrap(), json_data);
     }
 
     #[test]
@@ -120,7 +122,7 @@ mod tests {
             "type":"m.ignored_user_list"
         });
 
-        let actual = from_value::<EventResult<IgnoredUserListEvent>>(json_data)
+        let actual = from_json_value::<EventResult<IgnoredUserListEvent>>(json_data)
             .unwrap()
             .into_result()
             .unwrap();

--- a/src/ignored_user_list.rs
+++ b/src/ignored_user_list.rs
@@ -100,10 +100,10 @@ mod tests {
         let json_data = json!({
             "content": {
                 "ignored_users": {
-                    "@carl:example.com":{}
+                    "@carl:example.com": {}
                 }
             },
-            "type":"m.ignored_user_list"
+            "type": "m.ignored_user_list"
         });
 
         assert_eq!(to_json_value(ignored_user_list_event).unwrap(), json_data);
@@ -114,10 +114,10 @@ mod tests {
         let json_data = json!({
             "content": {
                 "ignored_users": {
-                    "@carl:example.com":{}
+                    "@carl:example.com": {}
                 }
             },
-            "type":"m.ignored_user_list"
+            "type": "m.ignored_user_list"
         });
 
         let actual = from_json_value::<EventResult<IgnoredUserListEvent>>(json_data)

--- a/src/key/verification/cancel.rs
+++ b/src/key/verification/cancel.rs
@@ -134,27 +134,29 @@ impl From<CancelCode> for String {
 
 #[cfg(test)]
 mod tests {
-    use serde_json::{from_str, to_string};
+    use serde_json::from_value as from_json_value;
+    use serde_json::json;
+    use serde_json::to_value as to_json_value;
 
     use super::CancelCode;
 
     #[test]
     fn cancel_codes_serialize_to_display_form() {
-        assert_eq!(to_string(&CancelCode::User).unwrap(), r#""m.user""#);
+        assert_eq!(to_json_value(&CancelCode::User).unwrap(), json!("m.user"));
     }
 
     #[test]
     fn custom_cancel_codes_serialize_to_display_form() {
         assert_eq!(
-            to_string(&CancelCode::Custom("io.ruma.test".to_string())).unwrap(),
-            r#""io.ruma.test""#
+            to_json_value(&CancelCode::Custom("io.ruma.test".to_string())).unwrap(),
+            json!("io.ruma.test")
         );
     }
 
     #[test]
     fn cancel_codes_deserialize_from_display_form() {
         assert_eq!(
-            from_str::<CancelCode>(r#""m.user""#).unwrap(),
+            from_json_value::<CancelCode>(json!("m.user")).unwrap(),
             CancelCode::User
         );
     }
@@ -162,7 +164,7 @@ mod tests {
     #[test]
     fn custom_cancel_codes_deserialize_from_display_form() {
         assert_eq!(
-            from_str::<CancelCode>(r#""io.ruma.test""#).unwrap(),
+            from_json_value::<CancelCode>(json!("io.ruma.test")).unwrap(),
             CancelCode::Custom("io.ruma.test".to_string())
         )
     }

--- a/src/key/verification/cancel.rs
+++ b/src/key/verification/cancel.rs
@@ -134,9 +134,7 @@ impl From<CancelCode> for String {
 
 #[cfg(test)]
 mod tests {
-    use serde_json::from_value as from_json_value;
-    use serde_json::json;
-    use serde_json::to_value as to_json_value;
+    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
     use super::CancelCode;
 

--- a/src/key/verification/start.rs
+++ b/src/key/verification/start.rs
@@ -416,16 +416,16 @@ mod tests {
         };
 
         let json_data = json!({
-            "content":{
-                "from_device":"123",
-                "transaction_id":"456",
-                "method":"m.sas.v1",
-                "key_agreement_protocols":["curve25519"],
-                "hashes":["sha256"],
-                "message_authentication_codes":["hkdf-hmac-sha256"],
-                "short_authentication_string":["decimal"]
+            "content": {
+                "from_device": "123",
+                "transaction_id": "456",
+                "method": "m.sas.v1",
+                "key_agreement_protocols": ["curve25519"],
+                "hashes": ["sha256"],
+                "message_authentication_codes": ["hkdf-hmac-sha256"],
+                "short_authentication_string": ["decimal"]
             },
-            "type":"m.key.verification.start"
+            "type": "m.key.verification.start"
         });
 
         assert_eq!(to_json_value(&key_verification_start).unwrap(), json_data);
@@ -446,13 +446,13 @@ mod tests {
         );
 
         let json_data = json!({
-            "from_device":"123",
-            "transaction_id":"456",
-            "method":"m.sas.v1",
-            "hashes":["sha256"],
-            "key_agreement_protocols":["curve25519"],
-            "message_authentication_codes":["hkdf-hmac-sha256"],
-            "short_authentication_string":["decimal"]
+            "from_device": "123",
+            "transaction_id": "456",
+            "method": "m.sas.v1",
+            "hashes": ["sha256"],
+            "key_agreement_protocols": ["curve25519"],
+            "message_authentication_codes": ["hkdf-hmac-sha256"],
+            "short_authentication_string": ["decimal"]
         });
 
         // Deserialize the content struct separately to verify `TryFromRaw` is implemented for it.
@@ -470,15 +470,15 @@ mod tests {
 
         let json_data = json!({
             "content": {
-                "from_device":"123",
-                "transaction_id":"456",
-                "method":"m.sas.v1",
-                "key_agreement_protocols":["curve25519"],
-                "hashes":["sha256"],
-                "message_authentication_codes":["hkdf-hmac-sha256"],
-                "short_authentication_string":["decimal"]
+                "from_device": "123",
+                "transaction_id": "456",
+                "method": "m.sas.v1",
+                "key_agreement_protocols": ["curve25519"],
+                "hashes": ["sha256"],
+                "message_authentication_codes": ["hkdf-hmac-sha256"],
+                "short_authentication_string": ["decimal"]
             },
-            "type":"m.key.verification.start"
+            "type": "m.key.verification.start"
         });
 
         assert_eq!(
@@ -499,10 +499,11 @@ mod tests {
     #[test]
     fn deserialization_structure_mismatch() {
         // Missing several required fields.
-        let error = from_json_value::<EventResult<StartEventContent>>(json!({"from_device":"123"}))
-            .unwrap()
-            .into_result()
-            .unwrap_err();
+        let error =
+            from_json_value::<EventResult<StartEventContent>>(json!({"from_device": "123"}))
+                .unwrap()
+                .into_result()
+                .unwrap_err();
 
         assert!(error.message().contains("missing field"));
         assert!(error.is_deserialization());
@@ -511,13 +512,13 @@ mod tests {
     #[test]
     fn deserialization_validation_missing_required_key_agreement_protocols() {
         let json_data = json!({
-            "from_device":"123",
-            "transaction_id":"456",
-            "method":"m.sas.v1",
-            "key_agreement_protocols":[],
-            "hashes":["sha256"],
-            "message_authentication_codes":["hkdf-hmac-sha256"],
-            "short_authentication_string":["decimal"]
+            "from_device": "123",
+            "transaction_id": "456",
+            "method": "m.sas.v1",
+            "key_agreement_protocols": [],
+            "hashes": ["sha256"],
+            "message_authentication_codes": ["hkdf-hmac-sha256"],
+            "short_authentication_string": ["decimal"]
         });
 
         let error = from_json_value::<EventResult<StartEventContent>>(json_data)
@@ -532,13 +533,13 @@ mod tests {
     #[test]
     fn deserialization_validation_missing_required_hashes() {
         let json_data = json!({
-            "from_device":"123",
-            "transaction_id":"456",
-            "method":"m.sas.v1",
-            "key_agreement_protocols":["curve25519"],
-            "hashes":[],
-            "message_authentication_codes":["hkdf-hmac-sha256"],
-            "short_authentication_string":["decimal"]
+            "from_device": "123",
+            "transaction_id": "456",
+            "method": "m.sas.v1",
+            "key_agreement_protocols": ["curve25519"],
+            "hashes": [],
+            "message_authentication_codes": ["hkdf-hmac-sha256"],
+            "short_authentication_string": ["decimal"]
         });
         let error = from_json_value::<EventResult<StartEventContent>>(json_data)
             .unwrap()
@@ -552,13 +553,13 @@ mod tests {
     #[test]
     fn deserialization_validation_missing_required_message_authentication_codes() {
         let json_data = json!({
-            "from_device":"123",
-            "transaction_id":"456",
-            "method":"m.sas.v1",
-            "key_agreement_protocols":["curve25519"],
-            "hashes":["sha256"],
-            "message_authentication_codes":[],
-            "short_authentication_string":["decimal"]
+            "from_device": "123",
+            "transaction_id": "456",
+            "method": "m.sas.v1",
+            "key_agreement_protocols": ["curve25519"],
+            "hashes": ["sha256"],
+            "message_authentication_codes": [],
+            "short_authentication_string": ["decimal"]
         });
         let error = from_json_value::<EventResult<StartEventContent>>(json_data)
             .unwrap()
@@ -571,13 +572,14 @@ mod tests {
 
     #[test]
     fn deserialization_validation_missing_required_short_authentication_string() {
-        let json_data = json!({"from_device":"123",
-            "transaction_id":"456",
-            "method":"m.sas.v1",
-            "key_agreement_protocols":["curve25519"],
-            "hashes":["sha256"],
-            "message_authentication_codes":["hkdf-hmac-sha256"],
-            "short_authentication_string":[]
+        let json_data = json!({
+            "from_device": "123",
+            "transaction_id": "456",
+            "method": "m.sas.v1",
+            "key_agreement_protocols": ["curve25519"],
+            "hashes": ["sha256"],
+            "message_authentication_codes": ["hkdf-hmac-sha256"],
+            "short_authentication_string": []
         });
         let error = from_json_value::<EventResult<StartEventContent>>(json_data)
             .unwrap()
@@ -592,14 +594,16 @@ mod tests {
     fn deserialization_of_event_validates_content() {
         // This JSON is missing the required value of "curve25519" for "key_agreement_protocols".
         let json_data = json!({
-            "content":{"from_device":"123",
-            "transaction_id":"456",
-            "method":"m.sas.v1",
-            "key_agreement_protocols":[],
-            "hashes":["sha256"],
-            "message_authentication_codes":["hkdf-hmac-sha256"],
-            "short_authentication_string":["decimal"]},
-            "type":"m.key.verification.start"
+            "content": {
+                "from_device": "123",
+                "transaction_id": "456",
+                "method": "m.sas.v1",
+                "key_agreement_protocols": [],
+                "hashes": ["sha256"],
+                "message_authentication_codes": ["hkdf-hmac-sha256"],
+                "short_authentication_string": ["decimal"]
+            },
+            "type": "m.key.verification.start"
         });
         let error = from_json_value::<EventResult<StartEvent>>(json_data)
             .unwrap()

--- a/src/key/verification/start.rs
+++ b/src/key/verification/start.rs
@@ -325,7 +325,9 @@ impl Serialize for MSasV1Content {
 
 #[cfg(test)]
 mod tests {
-    use serde_json::to_string;
+    use serde_json::from_value as from_json_value;
+    use serde_json::json;
+    use serde_json::to_value as to_json_value;
 
     use super::{
         HashAlgorithm, KeyAgreementProtocol, MSasV1Content, MSasV1ContentOptions,
@@ -415,10 +417,20 @@ mod tests {
             content: key_verification_start_content,
         };
 
-        assert_eq!(
-            to_string(&key_verification_start).unwrap(),
-            r#"{"content":{"from_device":"123","transaction_id":"456","method":"m.sas.v1","key_agreement_protocols":["curve25519"],"hashes":["sha256"],"message_authentication_codes":["hkdf-hmac-sha256"],"short_authentication_string":["decimal"]},"type":"m.key.verification.start"}"#
-        );
+        let json_data = json!({
+            "content":{
+                "from_device":"123",
+                "transaction_id":"456",
+                "method":"m.sas.v1",
+                "key_agreement_protocols":["curve25519"],
+                "hashes":["sha256"],
+                "message_authentication_codes":["hkdf-hmac-sha256"],
+                "short_authentication_string":["decimal"]
+            },
+            "type":"m.key.verification.start"
+        });
+
+        assert_eq!(to_json_value(&key_verification_start).unwrap(), json_data);
     }
 
     #[test]
@@ -435,11 +447,19 @@ mod tests {
             .unwrap(),
         );
 
+        let json_data = json!({
+            "from_device":"123",
+            "transaction_id":"456",
+            "method":"m.sas.v1",
+            "hashes":["sha256"],
+            "key_agreement_protocols":["curve25519"],
+            "message_authentication_codes":["hkdf-hmac-sha256"],
+            "short_authentication_string":["decimal"]
+        });
+
         // Deserialize the content struct separately to verify `TryFromRaw` is implemented for it.
         assert_eq!(
-            serde_json::from_str::<EventResult<StartEventContent>>(
-                r#"{"from_device":"123","transaction_id":"456","method":"m.sas.v1","hashes":["sha256"],"key_agreement_protocols":["curve25519"],"message_authentication_codes":["hkdf-hmac-sha256"],"short_authentication_string":["decimal"]}"#
-            )
+            from_json_value::<EventResult<StartEventContent>>(json_data)
                 .unwrap()
                 .into_result()
                 .unwrap(),
@@ -450,10 +470,21 @@ mod tests {
             content: key_verification_start_content,
         };
 
+        let json_data = json!({
+            "content": {
+                "from_device":"123",
+                "transaction_id":"456",
+                "method":"m.sas.v1",
+                "key_agreement_protocols":["curve25519"],
+                "hashes":["sha256"],
+                "message_authentication_codes":["hkdf-hmac-sha256"],
+                "short_authentication_string":["decimal"]
+            },
+            "type":"m.key.verification.start"
+        });
+
         assert_eq!(
-            serde_json::from_str::<EventResult<StartEvent>>(
-                r#"{"content":{"from_device":"123","transaction_id":"456","method":"m.sas.v1","key_agreement_protocols":["curve25519"],"hashes":["sha256"],"message_authentication_codes":["hkdf-hmac-sha256"],"short_authentication_string":["decimal"]},"type":"m.key.verification.start"}"#
-            )
+            from_json_value::<EventResult<StartEvent>>(json_data)
                 .unwrap()
                 .into_result()
                 .unwrap(),
@@ -470,11 +501,10 @@ mod tests {
     #[test]
     fn deserialization_structure_mismatch() {
         // Missing several required fields.
-        let error =
-            serde_json::from_str::<EventResult<StartEventContent>>(r#"{"from_device":"123"}"#)
-                .unwrap()
-                .into_result()
-                .unwrap_err();
+        let error = from_json_value::<EventResult<StartEventContent>>(json!({"from_device":"123"}))
+            .unwrap()
+            .into_result()
+            .unwrap_err();
 
         assert!(error.message().contains("missing field"));
         assert!(error.is_deserialization());
@@ -482,13 +512,20 @@ mod tests {
 
     #[test]
     fn deserialization_validation_missing_required_key_agreement_protocols() {
-        let error =
-            serde_json::from_str::<EventResult<StartEventContent>>(
-                r#"{"from_device":"123","transaction_id":"456","method":"m.sas.v1","key_agreement_protocols":[],"hashes":["sha256"],"message_authentication_codes":["hkdf-hmac-sha256"],"short_authentication_string":["decimal"]}"#
-            )
-                .unwrap()
-                .into_result()
-                .unwrap_err();
+        let json_data = json!({
+            "from_device":"123",
+            "transaction_id":"456",
+            "method":"m.sas.v1",
+            "key_agreement_protocols":[],
+            "hashes":["sha256"],
+            "message_authentication_codes":["hkdf-hmac-sha256"],
+            "short_authentication_string":["decimal"]
+        });
+
+        let error = from_json_value::<EventResult<StartEventContent>>(json_data)
+            .unwrap()
+            .into_result()
+            .unwrap_err();
 
         assert!(error.message().contains("key_agreement_protocols"));
         assert!(error.is_validation());
@@ -496,13 +533,19 @@ mod tests {
 
     #[test]
     fn deserialization_validation_missing_required_hashes() {
-        let error =
-            serde_json::from_str::<EventResult<StartEventContent>>(
-                r#"{"from_device":"123","transaction_id":"456","method":"m.sas.v1","key_agreement_protocols":["curve25519"],"hashes":[],"message_authentication_codes":["hkdf-hmac-sha256"],"short_authentication_string":["decimal"]}"#
-            )
-                .unwrap()
-                .into_result()
-                .unwrap_err();
+        let json_data = json!({
+            "from_device":"123",
+            "transaction_id":"456",
+            "method":"m.sas.v1",
+            "key_agreement_protocols":["curve25519"],
+            "hashes":[],
+            "message_authentication_codes":["hkdf-hmac-sha256"],
+            "short_authentication_string":["decimal"]
+        });
+        let error = from_json_value::<EventResult<StartEventContent>>(json_data)
+            .unwrap()
+            .into_result()
+            .unwrap_err();
 
         assert!(error.message().contains("hashes"));
         assert!(error.is_validation());
@@ -510,13 +553,19 @@ mod tests {
 
     #[test]
     fn deserialization_validation_missing_required_message_authentication_codes() {
-        let error =
-            serde_json::from_str::<EventResult<StartEventContent>>(
-                r#"{"from_device":"123","transaction_id":"456","method":"m.sas.v1","key_agreement_protocols":["curve25519"],"hashes":["sha256"],"message_authentication_codes":[],"short_authentication_string":["decimal"]}"#
-            )
-                .unwrap()
-                .into_result()
-                .unwrap_err();
+        let json_data = json!({
+            "from_device":"123",
+            "transaction_id":"456",
+            "method":"m.sas.v1",
+            "key_agreement_protocols":["curve25519"],
+            "hashes":["sha256"],
+            "message_authentication_codes":[],
+            "short_authentication_string":["decimal"]
+        });
+        let error = from_json_value::<EventResult<StartEventContent>>(json_data)
+            .unwrap()
+            .into_result()
+            .unwrap_err();
 
         assert!(error.message().contains("message_authentication_codes"));
         assert!(error.is_validation());
@@ -524,13 +573,18 @@ mod tests {
 
     #[test]
     fn deserialization_validation_missing_required_short_authentication_string() {
-        let error =
-            serde_json::from_str::<EventResult<StartEventContent>>(
-                r#"{"from_device":"123","transaction_id":"456","method":"m.sas.v1","key_agreement_protocols":["curve25519"],"hashes":["sha256"],"message_authentication_codes":["hkdf-hmac-sha256"],"short_authentication_string":[]}"#
-            )
-                .unwrap()
-                .into_result()
-                .unwrap_err();
+        let json_data = json!({"from_device":"123",
+            "transaction_id":"456",
+            "method":"m.sas.v1",
+            "key_agreement_protocols":["curve25519"],
+            "hashes":["sha256"],
+            "message_authentication_codes":["hkdf-hmac-sha256"],
+            "short_authentication_string":[]
+        });
+        let error = from_json_value::<EventResult<StartEventContent>>(json_data)
+            .unwrap()
+            .into_result()
+            .unwrap_err();
 
         assert!(error.message().contains("short_authentication_string"));
         assert!(error.is_validation());
@@ -539,13 +593,20 @@ mod tests {
     #[test]
     fn deserialization_of_event_validates_content() {
         // This JSON is missing the required value of "curve25519" for "key_agreement_protocols".
-        let error =
-            serde_json::from_str::<EventResult<StartEvent>>(
-                r#"{"content":{"from_device":"123","transaction_id":"456","method":"m.sas.v1","key_agreement_protocols":[],"hashes":["sha256"],"message_authentication_codes":["hkdf-hmac-sha256"],"short_authentication_string":["decimal"]},"type":"m.key.verification.start"}"#
-            )
-                .unwrap()
-                .into_result()
-                .unwrap_err();
+        let json_data = json!({
+            "content":{"from_device":"123",
+            "transaction_id":"456",
+            "method":"m.sas.v1",
+            "key_agreement_protocols":[],
+            "hashes":["sha256"],
+            "message_authentication_codes":["hkdf-hmac-sha256"],
+            "short_authentication_string":["decimal"]},
+            "type":"m.key.verification.start"
+        });
+        let error = from_json_value::<EventResult<StartEvent>>(json_data)
+            .unwrap()
+            .into_result()
+            .unwrap_err();
 
         assert!(error.message().contains("key_agreement_protocols"));
         assert!(error.is_validation());

--- a/src/key/verification/start.rs
+++ b/src/key/verification/start.rs
@@ -325,9 +325,7 @@ impl Serialize for MSasV1Content {
 
 #[cfg(test)]
 mod tests {
-    use serde_json::from_value as from_json_value;
-    use serde_json::json;
-    use serde_json::to_value as to_json_value;
+    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
     use super::{
         HashAlgorithm, KeyAgreementProtocol, MSasV1Content, MSasV1ContentOptions,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,6 +111,7 @@
 
 #![warn(rust_2018_idioms)]
 #![deny(missing_debug_implementations, missing_docs)]
+#![recursion_limit = "1024"]
 // Since we support Rust 1.36.0, we can't apply this suggestion yet
 #![allow(clippy::use_self)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,9 +109,9 @@
 //! However, the `ruma_events::collections::only::Event` enum does *not* include *m.room.message*,
 //! because *m.room.message* implements a *more specific* event trait than `Event`.
 
+#![recursion_limit = "1024"]
 #![warn(rust_2018_idioms)]
 #![deny(missing_debug_implementations, missing_docs)]
-#![recursion_limit = "1024"]
 // Since we support Rust 1.36.0, we can't apply this suggestion yet
 #![allow(clippy::use_self)]
 

--- a/src/presence.rs
+++ b/src/presence.rs
@@ -100,9 +100,9 @@ mod tests {
             "content": {
                 "avatar_url": "mxc://localhost:wefuiwegh8742w",
                 "currently_active": false,
-                "last_active_ago":2_478_593,
-                "presence":"online",
-                "status_msg":"Making cupcakes"
+                "last_active_ago": 2_478_593,
+                "presence": "online",
+                "status_msg": "Making cupcakes"
             },
             "sender": "@example:localhost",
             "type": "m.presence"
@@ -129,9 +129,9 @@ mod tests {
             "content": {
                 "avatar_url": "mxc://localhost:wefuiwegh8742w",
                 "currently_active": false,
-                "last_active_ago":2_478_593,
-                "presence":"online",
-                "status_msg":"Making cupcakes"
+                "last_active_ago": 2_478_593,
+                "presence": "online",
+                "status_msg": "Making cupcakes"
             },
             "sender": "@example:localhost",
             "type": "m.presence"

--- a/src/presence.rs
+++ b/src/presence.rs
@@ -77,7 +77,9 @@ mod tests {
 
     use js_int::UInt;
     use ruma_identifiers::UserId;
-    use serde_json::{from_value, json, to_value};
+    use serde_json::from_value as from_json_value;
+    use serde_json::json;
+    use serde_json::to_value as to_json_value;
 
     use super::{PresenceEvent, PresenceEventContent, PresenceState};
     use crate::EventResult;
@@ -100,7 +102,7 @@ mod tests {
             "content": {
                 "avatar_url": "mxc://localhost:wefuiwegh8742w",
                 "currently_active": false,
-                "last_active_ago":2478593,
+                "last_active_ago":2_478_593,
                 "presence":"online",
                 "status_msg":"Making cupcakes"
             },
@@ -108,7 +110,7 @@ mod tests {
             "type": "m.presence"
         });
 
-        assert_eq!(to_value(&event).unwrap(), json);
+        assert_eq!(to_json_value(&event).unwrap(), json);
     }
 
     #[test]
@@ -129,7 +131,7 @@ mod tests {
             "content": {
                 "avatar_url": "mxc://localhost:wefuiwegh8742w",
                 "currently_active": false,
-                "last_active_ago":2478593,
+                "last_active_ago":2_478_593,
                 "presence":"online",
                 "status_msg":"Making cupcakes"
             },
@@ -138,7 +140,7 @@ mod tests {
         });
 
         assert_eq!(
-            from_value::<EventResult<PresenceEvent>>(json)
+            from_json_value::<EventResult<PresenceEvent>>(json)
                 .unwrap()
                 .into_result()
                 .unwrap(),

--- a/src/presence.rs
+++ b/src/presence.rs
@@ -77,7 +77,7 @@ mod tests {
 
     use js_int::UInt;
     use ruma_identifiers::UserId;
-    use serde_json::to_string;
+    use serde_json::{from_value, json, to_value};
 
     use super::{PresenceEvent, PresenceEventContent, PresenceState};
     use crate::EventResult;
@@ -96,9 +96,19 @@ mod tests {
             sender: UserId::try_from("@example:localhost").unwrap(),
         };
 
-        let json = r#"{"content":{"avatar_url":"mxc://localhost:wefuiwegh8742w","currently_active":false,"last_active_ago":2478593,"presence":"online","status_msg":"Making cupcakes"},"sender":"@example:localhost","type":"m.presence"}"#;
+        let json = json!({
+            "content": {
+                "avatar_url": "mxc://localhost:wefuiwegh8742w",
+                "currently_active": false,
+                "last_active_ago":2478593,
+                "presence":"online",
+                "status_msg":"Making cupcakes"
+            },
+            "sender": "@example:localhost",
+            "type": "m.presence"
+        });
 
-        assert_eq!(to_string(&event).unwrap(), json);
+        assert_eq!(to_value(&event).unwrap(), json);
     }
 
     #[test]
@@ -115,10 +125,20 @@ mod tests {
             sender: UserId::try_from("@example:localhost").unwrap(),
         };
 
-        let json = r#"{"content":{"avatar_url":"mxc://localhost:wefuiwegh8742w","currently_active":false,"last_active_ago":2478593,"presence":"online","status_msg":"Making cupcakes"},"sender":"@example:localhost","type":"m.presence"}"#;
+        let json = json!({
+            "content": {
+                "avatar_url": "mxc://localhost:wefuiwegh8742w",
+                "currently_active": false,
+                "last_active_ago":2478593,
+                "presence":"online",
+                "status_msg":"Making cupcakes"
+            },
+            "sender": "@example:localhost",
+            "type": "m.presence"
+        });
 
         assert_eq!(
-            serde_json::from_str::<EventResult<PresenceEvent>>(json)
+            from_value::<EventResult<PresenceEvent>>(json)
                 .unwrap()
                 .into_result()
                 .unwrap(),

--- a/src/presence.rs
+++ b/src/presence.rs
@@ -77,9 +77,7 @@ mod tests {
 
     use js_int::UInt;
     use ruma_identifiers::UserId;
-    use serde_json::from_value as from_json_value;
-    use serde_json::json;
-    use serde_json::to_value as to_json_value;
+    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
     use super::{PresenceEvent, PresenceEventContent, PresenceState};
     use crate::EventResult;

--- a/src/push_rules.rs
+++ b/src/push_rules.rs
@@ -465,7 +465,7 @@ mod tests {
     fn serialize_tweak_highlight_action() {
         assert_eq!(
             to_json_value(&Action::SetTweak(Tweak::Highlight { value: true })).unwrap(),
-            json!({"set_tweak": "highlight", "value":true})
+            json!({"set_tweak": "highlight", "value": true})
         );
     }
 

--- a/src/push_rules.rs
+++ b/src/push_rules.rs
@@ -434,7 +434,9 @@ impl Serialize for SenderNotificationPermissionCondition {
 
 #[cfg(test)]
 mod tests {
-    use serde_json::{from_value, json, to_value};
+    use serde_json::from_value as from_json_value;
+    use serde_json::json;
+    use serde_json::to_value as to_json_value;
 
     use super::{
         Action, EventMatchCondition, PushCondition, PushRulesEvent, RoomMemberCountCondition,
@@ -444,13 +446,13 @@ mod tests {
 
     #[test]
     fn serialize_string_action() {
-        assert_eq!(to_value(&Action::Notify).unwrap(), json!("notify"));
+        assert_eq!(to_json_value(&Action::Notify).unwrap(), json!("notify"));
     }
 
     #[test]
     fn serialize_tweak_sound_action() {
         assert_eq!(
-            to_value(&Action::SetTweak(Tweak::Sound {
+            to_json_value(&Action::SetTweak(Tweak::Sound {
                 value: "default".to_string()
             }))
             .unwrap(),
@@ -464,7 +466,7 @@ mod tests {
     #[test]
     fn serialize_tweak_highlight_action() {
         assert_eq!(
-            to_value(&Action::SetTweak(Tweak::Highlight { value: true })).unwrap(),
+            to_json_value(&Action::SetTweak(Tweak::Highlight { value: true })).unwrap(),
             json!({"set_tweak": "highlight", "value":true})
         );
     }
@@ -472,7 +474,7 @@ mod tests {
     #[test]
     fn deserialize_string_action() {
         assert_eq!(
-            from_value::<Action>(json!("notify")).unwrap(),
+            from_json_value::<Action>(json!("notify")).unwrap(),
             Action::Notify
         );
     }
@@ -484,7 +486,7 @@ mod tests {
             "value": "default"
         });
         assert_eq!(
-            from_value::<Action>(json_data).unwrap(),
+            from_json_value::<Action>(json_data).unwrap(),
             Action::SetTweak(Tweak::Sound {
                 value: "default".to_string()
             })
@@ -498,7 +500,7 @@ mod tests {
             "value": true
         });
         assert_eq!(
-            from_value::<Action>(json_data).unwrap(),
+            from_json_value::<Action>(json_data).unwrap(),
             Action::SetTweak(Tweak::Highlight { value: true })
         );
     }
@@ -506,7 +508,7 @@ mod tests {
     #[test]
     fn deserialize_tweak_highlight_action_with_default_value() {
         assert_eq!(
-            from_value::<Action>(json!({"set_tweak": "highlight"})).unwrap(),
+            from_json_value::<Action>(json!({"set_tweak": "highlight"})).unwrap(),
             Action::SetTweak(Tweak::Highlight { value: true })
         );
     }
@@ -519,7 +521,7 @@ mod tests {
             "pattern": "m.notice"
         });
         assert_eq!(
-            to_value(&PushCondition::EventMatch(EventMatchCondition {
+            to_json_value(&PushCondition::EventMatch(EventMatchCondition {
                 key: "content.msgtype".to_string(),
                 pattern: "m.notice".to_string(),
             }))
@@ -531,7 +533,7 @@ mod tests {
     #[test]
     fn serialize_contains_display_name_condition() {
         assert_eq!(
-            to_value(&PushCondition::ContainsDisplayName).unwrap(),
+            to_json_value(&PushCondition::ContainsDisplayName).unwrap(),
             json!({"kind": "contains_display_name"})
         );
     }
@@ -543,7 +545,7 @@ mod tests {
             "kind": "room_member_count"
         });
         assert_eq!(
-            to_value(&PushCondition::RoomMemberCount(RoomMemberCountCondition {
+            to_json_value(&PushCondition::RoomMemberCount(RoomMemberCountCondition {
                 is: "2".to_string(),
             }))
             .unwrap(),
@@ -559,7 +561,7 @@ mod tests {
         });
         assert_eq!(
             json_data,
-            to_value(&PushCondition::SenderNotificationPermission(
+            to_json_value(&PushCondition::SenderNotificationPermission(
                 SenderNotificationPermissionCondition {
                     key: "room".to_string(),
                 }
@@ -576,7 +578,7 @@ mod tests {
             "pattern": "m.notice"
         });
         assert_eq!(
-            from_value::<PushCondition>(json_data).unwrap(),
+            from_json_value::<PushCondition>(json_data).unwrap(),
             PushCondition::EventMatch(EventMatchCondition {
                 key: "content.msgtype".to_string(),
                 pattern: "m.notice".to_string(),
@@ -587,7 +589,7 @@ mod tests {
     #[test]
     fn deserialize_contains_display_name_condition() {
         assert_eq!(
-            from_value::<PushCondition>(json!({"kind": "contains_display_name"})).unwrap(),
+            from_json_value::<PushCondition>(json!({"kind": "contains_display_name"})).unwrap(),
             PushCondition::ContainsDisplayName,
         );
     }
@@ -599,7 +601,7 @@ mod tests {
             "kind": "room_member_count"
         });
         assert_eq!(
-            from_value::<PushCondition>(json_data).unwrap(),
+            from_json_value::<PushCondition>(json_data).unwrap(),
             PushCondition::RoomMemberCount(RoomMemberCountCondition {
                 is: "2".to_string(),
             })
@@ -613,7 +615,7 @@ mod tests {
             "kind": "sender_notification_permission"
         });
         assert_eq!(
-            from_value::<PushCondition>(json_data).unwrap(),
+            from_json_value::<PushCondition>(json_data).unwrap(),
             PushCondition::SenderNotificationPermission(SenderNotificationPermissionCondition {
                 key: "room".to_string(),
             })
@@ -814,7 +816,7 @@ mod tests {
             },
             "type": "m.push_rules"
         });
-        assert!(from_value::<EventResult<PushRulesEvent>>(json_data)
+        assert!(from_json_value::<EventResult<PushRulesEvent>>(json_data)
             .unwrap()
             .into_result()
             .is_ok());

--- a/src/push_rules.rs
+++ b/src/push_rules.rs
@@ -434,7 +434,7 @@ impl Serialize for SenderNotificationPermissionCondition {
 
 #[cfg(test)]
 mod tests {
-    use serde_json::{from_str, to_string};
+    use serde_json::{from_value, json, to_value};
 
     use super::{
         Action, EventMatchCondition, PushCondition, PushRulesEvent, RoomMemberCountCondition,
@@ -444,37 +444,47 @@ mod tests {
 
     #[test]
     fn serialize_string_action() {
-        assert_eq!(to_string(&Action::Notify).unwrap(), r#""notify""#);
+        assert_eq!(to_value(&Action::Notify).unwrap(), json!("notify"));
     }
 
     #[test]
     fn serialize_tweak_sound_action() {
         assert_eq!(
-            to_string(&Action::SetTweak(Tweak::Sound {
+            to_value(&Action::SetTweak(Tweak::Sound {
                 value: "default".to_string()
             }))
             .unwrap(),
-            r#"{"set_tweak":"sound","value":"default"}"#
+            json!({
+                "set_tweak": "sound",
+                "value": "default"
+            })
         );
     }
 
     #[test]
     fn serialize_tweak_highlight_action() {
         assert_eq!(
-            to_string(&Action::SetTweak(Tweak::Highlight { value: true })).unwrap(),
-            r#"{"set_tweak":"highlight","value":true}"#
+            to_value(&Action::SetTweak(Tweak::Highlight { value: true })).unwrap(),
+            json!({"set_tweak": "highlight", "value":true})
         );
     }
 
     #[test]
     fn deserialize_string_action() {
-        assert_eq!(from_str::<Action>(r#""notify""#).unwrap(), Action::Notify);
+        assert_eq!(
+            from_value::<Action>(json!("notify")).unwrap(),
+            Action::Notify
+        );
     }
 
     #[test]
     fn deserialize_tweak_sound_action() {
+        let json_data = json!({
+            "set_tweak": "sound",
+            "value": "default"
+        });
         assert_eq!(
-            from_str::<Action>(r#"{"set_tweak":"sound","value":"default"}"#).unwrap(),
+            from_value::<Action>(json_data).unwrap(),
             Action::SetTweak(Tweak::Sound {
                 value: "default".to_string()
             })
@@ -483,8 +493,12 @@ mod tests {
 
     #[test]
     fn deserialize_tweak_highlight_action() {
+        let json_data = json!({
+            "set_tweak": "highlight",
+            "value": true
+        });
         assert_eq!(
-            from_str::<Action>(r#"{"set_tweak":"highlight","value":true}"#).unwrap(),
+            from_value::<Action>(json_data).unwrap(),
             Action::SetTweak(Tweak::Highlight { value: true })
         );
     }
@@ -492,62 +506,77 @@ mod tests {
     #[test]
     fn deserialize_tweak_highlight_action_with_default_value() {
         assert_eq!(
-            from_str::<Action>(r#"{"set_tweak":"highlight"}"#).unwrap(),
+            from_value::<Action>(json!({"set_tweak": "highlight"})).unwrap(),
             Action::SetTweak(Tweak::Highlight { value: true })
         );
     }
 
     #[test]
     fn serialize_event_match_condition() {
+        let json_data = json!({
+            "key": "content.msgtype",
+            "kind": "event_match",
+            "pattern": "m.notice"
+        });
         assert_eq!(
-            to_string(&PushCondition::EventMatch(EventMatchCondition {
+            to_value(&PushCondition::EventMatch(EventMatchCondition {
                 key: "content.msgtype".to_string(),
                 pattern: "m.notice".to_string(),
             }))
             .unwrap(),
-            r#"{"key":"content.msgtype","kind":"event_match","pattern":"m.notice"}"#
+            json_data
         );
     }
 
     #[test]
     fn serialize_contains_display_name_condition() {
         assert_eq!(
-            to_string(&PushCondition::ContainsDisplayName).unwrap(),
-            r#"{"kind":"contains_display_name"}"#
+            to_value(&PushCondition::ContainsDisplayName).unwrap(),
+            json!({"kind": "contains_display_name"})
         );
     }
 
     #[test]
     fn serialize_room_member_count_condition() {
+        let json_data = json!({
+            "is": "2",
+            "kind": "room_member_count"
+        });
         assert_eq!(
-            to_string(&PushCondition::RoomMemberCount(RoomMemberCountCondition {
+            to_value(&PushCondition::RoomMemberCount(RoomMemberCountCondition {
                 is: "2".to_string(),
             }))
             .unwrap(),
-            r#"{"is":"2","kind":"room_member_count"}"#
+            json_data
         );
     }
 
     #[test]
     fn serialize_sender_notification_permission_condition() {
+        let json_data = json!({
+            "key": "room",
+            "kind": "sender_notification_permission"
+        });
         assert_eq!(
-            r#"{"key":"room","kind":"sender_notification_permission"}"#,
-            to_string(&PushCondition::SenderNotificationPermission(
+            json_data,
+            to_value(&PushCondition::SenderNotificationPermission(
                 SenderNotificationPermissionCondition {
                     key: "room".to_string(),
                 }
             ))
-            .unwrap(),
+            .unwrap()
         );
     }
 
     #[test]
     fn deserialize_event_match_condition() {
+        let json_data = json!({
+            "key": "content.msgtype",
+            "kind": "event_match",
+            "pattern": "m.notice"
+        });
         assert_eq!(
-            from_str::<PushCondition>(
-                r#"{"key":"content.msgtype","kind":"event_match","pattern":"m.notice"}"#
-            )
-            .unwrap(),
+            from_value::<PushCondition>(json_data).unwrap(),
             PushCondition::EventMatch(EventMatchCondition {
                 key: "content.msgtype".to_string(),
                 pattern: "m.notice".to_string(),
@@ -558,15 +587,19 @@ mod tests {
     #[test]
     fn deserialize_contains_display_name_condition() {
         assert_eq!(
-            from_str::<PushCondition>(r#"{"kind":"contains_display_name"}"#).unwrap(),
+            from_value::<PushCondition>(json!({"kind": "contains_display_name"})).unwrap(),
             PushCondition::ContainsDisplayName,
         );
     }
 
     #[test]
     fn deserialize_room_member_count_condition() {
+        let json_data = json!({
+            "is": "2",
+            "kind": "room_member_count"
+        });
         assert_eq!(
-            from_str::<PushCondition>(r#"{"is":"2","kind":"room_member_count"}"#).unwrap(),
+            from_value::<PushCondition>(json_data).unwrap(),
             PushCondition::RoomMemberCount(RoomMemberCountCondition {
                 is: "2".to_string(),
             })
@@ -575,9 +608,12 @@ mod tests {
 
     #[test]
     fn deserialize_sender_notification_permission_condition() {
+        let json_data = json!({
+            "key": "room",
+            "kind": "sender_notification_permission"
+        });
         assert_eq!(
-            from_str::<PushCondition>(r#"{"key":"room","kind":"sender_notification_permission"}"#)
-                .unwrap(),
+            from_value::<PushCondition>(json_data).unwrap(),
             PushCondition::SenderNotificationPermission(SenderNotificationPermissionCondition {
                 key: "room".to_string(),
             })
@@ -587,134 +623,134 @@ mod tests {
     #[test]
     fn sanity_check() {
         // This is a full example of a push rules event from the specification.
-        let json = r#"{
-    "content": {
-        "global": {
-            "content": [
-                {
-                    "actions": [
-                        "notify",
-                        {
-                            "set_tweak": "sound",
-                            "value": "default"
-                        },
-                        {
-                            "set_tweak": "highlight"
-                        }
+        let json_data = json!({
+            "content": {
+                "global": {
+                    "content": [
+                    {
+                        "actions": [
+                            "notify",
+                            {
+                                "set_tweak": "sound",
+                                "value": "default"
+                            },
+                            {
+                                "set_tweak": "highlight"
+                            }
+                        ],
+                        "default": true,
+                        "enabled": true,
+                        "pattern": "alice",
+                        "rule_id": ".m.rule.contains_user_name"
+                    }
                     ],
-                    "default": true,
-                    "enabled": true,
-                    "pattern": "alice",
-                    "rule_id": ".m.rule.contains_user_name"
-                }
-            ],
-            "override": [
-                {
-                    "actions": [
-                        "dont_notify"
-                    ],
-                    "conditions": [],
-                    "default": true,
-                    "enabled": false,
-                    "rule_id": ".m.rule.master"
-                },
-                {
-                    "actions": [
-                        "dont_notify"
-                    ],
-                    "conditions": [
+                    "override": [
+                    {
+                        "actions": [
+                            "dont_notify"
+                        ],
+                        "conditions": [],
+                        "default": true,
+                        "enabled": false,
+                        "rule_id": ".m.rule.master"
+                    },
+                    {
+                        "actions": [
+                            "dont_notify"
+                        ],
+                        "conditions": [
                         {
                             "key": "content.msgtype",
                             "kind": "event_match",
                             "pattern": "m.notice"
                         }
+                        ],
+                        "default": true,
+                        "enabled": true,
+                        "rule_id": ".m.rule.suppress_notices"
+                    }
                     ],
-                    "default": true,
-                    "enabled": true,
-                    "rule_id": ".m.rule.suppress_notices"
-                }
-            ],
-            "room": [],
-            "sender": [],
-            "underride": [
-                {
-                    "actions": [
-                        "notify",
-                        {
-                            "set_tweak": "sound",
-                            "value": "ring"
-                        },
-                        {
-                            "set_tweak": "highlight",
-                            "value": false
-                        }
-                    ],
-                    "conditions": [
+                    "room": [],
+                    "sender": [],
+                    "underride": [
+                    {
+                        "actions": [
+                            "notify",
+                            {
+                                "set_tweak": "sound",
+                                "value": "ring"
+                            },
+                            {
+                                "set_tweak": "highlight",
+                                "value": false
+                            }
+                        ],
+                        "conditions": [
                         {
                             "key": "type",
                             "kind": "event_match",
                             "pattern": "m.call.invite"
                         }
-                    ],
-                    "default": true,
-                    "enabled": true,
-                    "rule_id": ".m.rule.call"
-                },
-                {
-                    "actions": [
-                        "notify",
-                        {
-                            "set_tweak": "sound",
-                            "value": "default"
-                        },
-                        {
-                            "set_tweak": "highlight"
-                        }
-                    ],
-                    "conditions": [
+                        ],
+                        "default": true,
+                        "enabled": true,
+                        "rule_id": ".m.rule.call"
+                    },
+                    {
+                        "actions": [
+                            "notify",
+                            {
+                                "set_tweak": "sound",
+                                "value": "default"
+                            },
+                            {
+                                "set_tweak": "highlight"
+                            }
+                        ],
+                        "conditions": [
                         {
                             "kind": "contains_display_name"
                         }
-                    ],
-                    "default": true,
-                    "enabled": true,
-                    "rule_id": ".m.rule.contains_display_name"
-                },
-                {
-                    "actions": [
-                        "notify",
-                        {
-                            "set_tweak": "sound",
-                            "value": "default"
-                        },
-                        {
-                            "set_tweak": "highlight",
-                            "value": false
-                        }
-                    ],
-                    "conditions": [
+                        ],
+                        "default": true,
+                        "enabled": true,
+                        "rule_id": ".m.rule.contains_display_name"
+                    },
+                    {
+                        "actions": [
+                            "notify",
+                            {
+                                "set_tweak": "sound",
+                                "value": "default"
+                            },
+                            {
+                                "set_tweak": "highlight",
+                                "value": false
+                            }
+                        ],
+                        "conditions": [
                         {
                             "is": "2",
                             "kind": "room_member_count"
                         }
-                    ],
-                    "default": true,
-                    "enabled": true,
-                    "rule_id": ".m.rule.room_one_to_one"
-                },
-                {
-                    "actions": [
-                        "notify",
-                        {
-                            "set_tweak": "sound",
-                            "value": "default"
-                        },
-                        {
-                            "set_tweak": "highlight",
-                            "value": false
-                        }
-                    ],
-                    "conditions": [
+                        ],
+                        "default": true,
+                        "enabled": true,
+                        "rule_id": ".m.rule.room_one_to_one"
+                    },
+                    {
+                        "actions": [
+                            "notify",
+                            {
+                                "set_tweak": "sound",
+                                "value": "default"
+                            },
+                            {
+                                "set_tweak": "highlight",
+                                "value": false
+                            }
+                        ],
+                        "conditions": [
                         {
                             "key": "type",
                             "kind": "event_match",
@@ -730,55 +766,55 @@ mod tests {
                             "kind": "event_match",
                             "pattern": "@alice:example.com"
                         }
-                    ],
-                    "default": true,
-                    "enabled": true,
-                    "rule_id": ".m.rule.invite_for_me"
-                },
-                {
-                    "actions": [
-                        "notify",
-                        {
-                            "set_tweak": "highlight",
-                            "value": false
-                        }
-                    ],
-                    "conditions": [
+                        ],
+                        "default": true,
+                        "enabled": true,
+                        "rule_id": ".m.rule.invite_for_me"
+                    },
+                    {
+                        "actions": [
+                            "notify",
+                            {
+                                "set_tweak": "highlight",
+                                "value": false
+                            }
+                        ],
+                        "conditions": [
                         {
                             "key": "type",
                             "kind": "event_match",
                             "pattern": "m.room.member"
                         }
-                    ],
-                    "default": true,
-                    "enabled": true,
-                    "rule_id": ".m.rule.member_event"
-                },
-                {
-                    "actions": [
-                        "notify",
-                        {
-                            "set_tweak": "highlight",
-                            "value": false
-                        }
-                    ],
-                    "conditions": [
+                        ],
+                        "default": true,
+                        "enabled": true,
+                        "rule_id": ".m.rule.member_event"
+                    },
+                    {
+                        "actions": [
+                            "notify",
+                            {
+                                "set_tweak": "highlight",
+                                "value": false
+                            }
+                        ],
+                        "conditions": [
                         {
                             "key": "type",
                             "kind": "event_match",
                             "pattern": "m.room.message"
                         }
-                    ],
-                    "default": true,
-                    "enabled": true,
-                    "rule_id": ".m.rule.message"
+                        ],
+                        "default": true,
+                        "enabled": true,
+                        "rule_id": ".m.rule.message"
+                    }
+                    ]
                 }
-            ]
-        }
-    },
-    "type": "m.push_rules"
-}"#;
-        assert!(serde_json::from_str::<EventResult<PushRulesEvent>>(json)
+            },
+            "type": "m.push_rules"
+        });
+        assert!(from_value::<EventResult<PushRulesEvent>>(json_data)
             .unwrap()
             .into_result()
             .is_ok());

--- a/src/push_rules.rs
+++ b/src/push_rules.rs
@@ -434,9 +434,7 @@ impl Serialize for SenderNotificationPermissionCondition {
 
 #[cfg(test)]
 mod tests {
-    use serde_json::from_value as from_json_value;
-    use serde_json::json;
-    use serde_json::to_value as to_json_value;
+    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
     use super::{
         Action, EventMatchCondition, PushCondition, PushRulesEvent, RoomMemberCountCondition,

--- a/src/room/canonical_alias.rs
+++ b/src/room/canonical_alias.rs
@@ -174,9 +174,7 @@ mod tests {
 
     use js_int::UInt;
     use ruma_identifiers::{EventId, RoomAliasId, UserId};
-    use serde_json::from_value as from_json_value;
-    use serde_json::to_value as to_json_value;
-    use serde_json::{json, Map};
+    use serde_json::{from_value as from_json_value, json, to_value as to_json_value, Map};
 
     use super::{CanonicalAliasEvent, CanonicalAliasEventContent};
     use crate::EventResult;

--- a/src/room/canonical_alias.rs
+++ b/src/room/canonical_alias.rs
@@ -196,14 +196,14 @@ mod tests {
 
         let actual = to_json_value(&canonical_alias_event).unwrap();
         let expected = json!({
-            "content":{
-                "alias":"#somewhere:localhost"
+            "content": {
+                "alias": "#somewhere:localhost"
             },
-            "event_id":"$h29iv0s8:example.com",
-            "origin_server_ts":1,
-            "sender":"@carl:example.com",
-            "state_key":"",
-            "type":"m.room.canonical_alias"
+            "event_id": "$h29iv0s8:example.com",
+            "origin_server_ts": 1,
+            "sender": "@carl:example.com",
+            "state_key": "",
+            "type": "m.room.canonical_alias"
         });
 
         assert_eq!(actual, expected);
@@ -212,12 +212,12 @@ mod tests {
     #[test]
     fn absent_field_as_none() {
         let json_data = json!({
-            "content":{},
-            "event_id":"$h29iv0s8:example.com",
-            "origin_server_ts":1,
-            "sender":"@carl:example.com",
-            "state_key":"",
-            "type":"m.room.canonical_alias"
+            "content": {},
+            "event_id": "$h29iv0s8:example.com",
+            "origin_server_ts": 1,
+            "sender": "@carl:example.com",
+            "state_key": "",
+            "type": "m.room.canonical_alias"
         });
 
         assert_eq!(
@@ -234,14 +234,14 @@ mod tests {
     #[test]
     fn null_field_as_none() {
         let json_data = json!({
-            "content":{
-                "alias":null
+            "content": {
+                "alias": null
             },
-            "event_id":"$h29iv0s8:example.com",
-            "origin_server_ts":1,
-            "sender":"@carl:example.com",
-            "state_key":"",
-            "type":"m.room.canonical_alias"
+            "event_id": "$h29iv0s8:example.com",
+            "origin_server_ts": 1,
+            "sender": "@carl:example.com",
+            "state_key": "",
+            "type": "m.room.canonical_alias"
         });
         assert_eq!(
             from_json_value::<EventResult<CanonicalAliasEvent>>(json_data)
@@ -258,13 +258,13 @@ mod tests {
     fn empty_field_as_none() {
         let json_data = json!({
             "content": {
-                "alias":""
+                "alias": ""
             },
-            "event_id":"$h29iv0s8:example.com",
-            "origin_server_ts":1,
-            "sender":"@carl:example.com",
-            "state_key":"",
-            "type":"m.room.canonical_alias"
+            "event_id": "$h29iv0s8:example.com",
+            "origin_server_ts": 1,
+            "sender": "@carl:example.com",
+            "state_key": "",
+            "type": "m.room.canonical_alias"
         });
         assert_eq!(
             from_json_value::<EventResult<CanonicalAliasEvent>>(json_data)
@@ -281,14 +281,14 @@ mod tests {
     fn nonempty_field_as_some() {
         let alias = Some(RoomAliasId::try_from("#somewhere:localhost").unwrap());
         let json_data = json!({
-            "content":{
-                "alias":"#somewhere:localhost"
+            "content": {
+                "alias": "#somewhere:localhost"
             },
-            "event_id":"$h29iv0s8:example.com",
-            "origin_server_ts":1,
-            "sender":"@carl:example.com",
-            "state_key":"",
-            "type":"m.room.canonical_alias"
+            "event_id": "$h29iv0s8:example.com",
+            "origin_server_ts": 1,
+            "sender": "@carl:example.com",
+            "state_key": "",
+            "type": "m.room.canonical_alias"
         });
         assert_eq!(
             from_json_value::<EventResult<CanonicalAliasEvent>>(json_data)

--- a/src/room/canonical_alias.rs
+++ b/src/room/canonical_alias.rs
@@ -174,7 +174,9 @@ mod tests {
 
     use js_int::UInt;
     use ruma_identifiers::{EventId, RoomAliasId, UserId};
-    use serde_json::Map;
+    use serde_json::from_value as from_json_value;
+    use serde_json::to_value as to_json_value;
+    use serde_json::{json, Map};
 
     use super::{CanonicalAliasEvent, CanonicalAliasEventContent};
     use crate::EventResult;
@@ -194,18 +196,34 @@ mod tests {
             unsigned: Map::new(),
         };
 
-        let actual = serde_json::to_string(&canonical_alias_event).unwrap();
-        let expected = r##"{"content":{"alias":"#somewhere:localhost"},"event_id":"$h29iv0s8:example.com","origin_server_ts":1,"sender":"@carl:example.com","state_key":"","type":"m.room.canonical_alias"}"##;
+        let actual = to_json_value(&canonical_alias_event).unwrap();
+        let expected = json!({
+            "content":{
+                "alias":"#somewhere:localhost"
+            },
+            "event_id":"$h29iv0s8:example.com",
+            "origin_server_ts":1,
+            "sender":"@carl:example.com",
+            "state_key":"",
+            "type":"m.room.canonical_alias"
+        });
 
         assert_eq!(actual, expected);
     }
 
     #[test]
     fn absent_field_as_none() {
+        let json_data = json!({
+            "content":{},
+            "event_id":"$h29iv0s8:example.com",
+            "origin_server_ts":1,
+            "sender":"@carl:example.com",
+            "state_key":"",
+            "type":"m.room.canonical_alias"
+        });
+
         assert_eq!(
-            serde_json::from_str::<EventResult<CanonicalAliasEvent>>(
-                r#"{"content":{},"event_id":"$h29iv0s8:example.com","origin_server_ts":1,"sender":"@carl:example.com","state_key":"","type":"m.room.canonical_alias"}"#
-            )
+            from_json_value::<EventResult<CanonicalAliasEvent>>(json_data)
                 .unwrap()
                 .into_result()
                 .unwrap()
@@ -217,10 +235,18 @@ mod tests {
 
     #[test]
     fn null_field_as_none() {
+        let json_data = json!({
+            "content":{
+                "alias":null
+            },
+            "event_id":"$h29iv0s8:example.com",
+            "origin_server_ts":1,
+            "sender":"@carl:example.com",
+            "state_key":"",
+            "type":"m.room.canonical_alias"
+        });
         assert_eq!(
-            serde_json::from_str::<EventResult<CanonicalAliasEvent>>(
-                r#"{"content":{"alias":null},"event_id":"$h29iv0s8:example.com","origin_server_ts":1,"sender":"@carl:example.com","state_key":"","type":"m.room.canonical_alias"}"#
-            )
+            from_json_value::<EventResult<CanonicalAliasEvent>>(json_data)
                 .unwrap()
                 .into_result()
                 .unwrap()
@@ -232,10 +258,18 @@ mod tests {
 
     #[test]
     fn empty_field_as_none() {
+        let json_data = json!({
+            "content": {
+                "alias":""
+            },
+            "event_id":"$h29iv0s8:example.com",
+            "origin_server_ts":1,
+            "sender":"@carl:example.com",
+            "state_key":"",
+            "type":"m.room.canonical_alias"
+        });
         assert_eq!(
-            serde_json::from_str::<EventResult<CanonicalAliasEvent>>(
-                r#"{"content":{"alias":""},"event_id":"$h29iv0s8:example.com","origin_server_ts":1,"sender":"@carl:example.com","state_key":"","type":"m.room.canonical_alias"}"#
-            )
+            from_json_value::<EventResult<CanonicalAliasEvent>>(json_data)
                 .unwrap()
                 .into_result()
                 .unwrap()
@@ -248,11 +282,18 @@ mod tests {
     #[test]
     fn nonempty_field_as_some() {
         let alias = Some(RoomAliasId::try_from("#somewhere:localhost").unwrap());
-
+        let json_data = json!({
+            "content":{
+                "alias":"#somewhere:localhost"
+            },
+            "event_id":"$h29iv0s8:example.com",
+            "origin_server_ts":1,
+            "sender":"@carl:example.com",
+            "state_key":"",
+            "type":"m.room.canonical_alias"
+        });
         assert_eq!(
-            serde_json::from_str::<EventResult<CanonicalAliasEvent>>(
-                r##"{"content":{"alias":"#somewhere:localhost"},"event_id":"$h29iv0s8:example.com","origin_server_ts":1,"sender":"@carl:example.com","state_key":"","type":"m.room.canonical_alias"}"##
-            )
+            from_json_value::<EventResult<CanonicalAliasEvent>>(json_data)
                 .unwrap()
                 .into_result()
                 .unwrap()

--- a/src/room/create.rs
+++ b/src/room/create.rs
@@ -54,6 +54,9 @@ mod tests {
     use std::convert::TryFrom;
 
     use ruma_identifiers::{RoomVersionId, UserId};
+    use serde_json::from_value as from_json_value;
+    use serde_json::json;
+    use serde_json::to_value as to_json_value;
 
     use super::CreateEventContent;
     use crate::EventResult;
@@ -67,9 +70,13 @@ mod tests {
             predecessor: None,
         };
 
-        let json = r#"{"creator":"@carl:example.com","m.federate":true,"room_version":"4"}"#;
+        let json = json!({
+            "creator":"@carl:example.com",
+            "m.federate":true,
+            "room_version":"4"
+        });
 
-        assert_eq!(serde_json::to_string(&content).unwrap(), json);
+        assert_eq!(to_json_value(&content).unwrap(), json);
     }
 
     #[test]
@@ -81,10 +88,14 @@ mod tests {
             predecessor: None,
         };
 
-        let json = r#"{"creator":"@carl:example.com","m.federate":true,"room_version":"4"}"#;
+        let json = json!({
+            "creator":"@carl:example.com",
+            "m.federate":true,
+            "room_version":"4"
+        });
 
         assert_eq!(
-            serde_json::from_str::<EventResult<CreateEventContent>>(json)
+            from_json_value::<EventResult<CreateEventContent>>(json)
                 .unwrap()
                 .into_result()
                 .unwrap(),

--- a/src/room/create.rs
+++ b/src/room/create.rs
@@ -54,9 +54,7 @@ mod tests {
     use std::convert::TryFrom;
 
     use ruma_identifiers::{RoomVersionId, UserId};
-    use serde_json::from_value as from_json_value;
-    use serde_json::json;
-    use serde_json::to_value as to_json_value;
+    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
     use super::CreateEventContent;
     use crate::EventResult;

--- a/src/room/create.rs
+++ b/src/room/create.rs
@@ -69,9 +69,9 @@ mod tests {
         };
 
         let json = json!({
-            "creator":"@carl:example.com",
-            "m.federate":true,
-            "room_version":"4"
+            "creator": "@carl:example.com",
+            "m.federate": true,
+            "room_version": "4"
         });
 
         assert_eq!(to_json_value(&content).unwrap(), json);
@@ -87,9 +87,9 @@ mod tests {
         };
 
         let json = json!({
-            "creator":"@carl:example.com",
-            "m.federate":true,
-            "room_version":"4"
+            "creator": "@carl:example.com",
+            "m.federate": true,
+            "room_version": "4"
         });
 
         assert_eq!(

--- a/src/room/encrypted.rs
+++ b/src/room/encrypted.rs
@@ -295,11 +295,11 @@ mod tests {
             });
 
         let json_data = json!({
-            "algorithm":"m.megolm.v1.aes-sha2",
-            "ciphertext":"ciphertext",
-            "sender_key":"sender_key",
-            "device_id":"device_id",
-            "session_id":"session_id"
+            "algorithm": "m.megolm.v1.aes-sha2",
+            "ciphertext": "ciphertext",
+            "sender_key": "sender_key",
+            "device_id": "device_id",
+            "session_id": "session_id"
         });
 
         assert_eq!(
@@ -320,11 +320,11 @@ mod tests {
             });
 
         let json_data = json!({
-            "algorithm":"m.megolm.v1.aes-sha2",
-            "ciphertext":"ciphertext",
-            "sender_key":"sender_key",
-            "device_id":"device_id",
-            "session_id":"session_id"
+            "algorithm": "m.megolm.v1.aes-sha2",
+            "ciphertext": "ciphertext",
+            "sender_key": "sender_key",
+            "device_id": "device_id",
+            "session_id": "session_id"
         });
 
         assert_eq!(
@@ -339,7 +339,7 @@ mod tests {
     #[test]
     fn deserialization_olm() {
         let json_data = json!({
-            "sender_key":"test_key",
+            "sender_key": "test_key",
             "ciphertext": {
                 "test_curve_key": {
                     "body": "encrypted_body",
@@ -368,7 +368,7 @@ mod tests {
     #[test]
     fn deserialization_failure() {
         assert!(from_json_value::<EventResult<EncryptedEventContent>>(
-            json!({"algorithm":"m.megolm.v1.aes-sha2"})
+            json!({"algorithm": "m.megolm.v1.aes-sha2"})
         )
         .unwrap()
         .into_result()

--- a/src/room/encrypted.rs
+++ b/src/room/encrypted.rs
@@ -278,9 +278,7 @@ pub struct MegolmV1AesSha2Content {
 
 #[cfg(test)]
 mod tests {
-    use serde_json::from_value as from_json_value;
-    use serde_json::json;
-    use serde_json::to_value as to_json_value;
+    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
     use super::{Algorithm, EncryptedEventContent, MegolmV1AesSha2Content};
     use crate::EventResult;

--- a/src/room/encrypted.rs
+++ b/src/room/encrypted.rs
@@ -278,7 +278,9 @@ pub struct MegolmV1AesSha2Content {
 
 #[cfg(test)]
 mod tests {
-    use serde_json::to_string;
+    use serde_json::from_value as from_json_value;
+    use serde_json::json;
+    use serde_json::to_value as to_json_value;
 
     use super::{Algorithm, EncryptedEventContent, MegolmV1AesSha2Content};
     use crate::EventResult;
@@ -294,9 +296,17 @@ mod tests {
                 session_id: "session_id".to_string(),
             });
 
+        let json_data = json!({
+            "algorithm":"m.megolm.v1.aes-sha2",
+            "ciphertext":"ciphertext",
+            "sender_key":"sender_key",
+            "device_id":"device_id",
+            "session_id":"session_id"
+        });
+
         assert_eq!(
-            to_string(&key_verification_start_content).unwrap(),
-            r#"{"algorithm":"m.megolm.v1.aes-sha2","ciphertext":"ciphertext","sender_key":"sender_key","device_id":"device_id","session_id":"session_id"}"#
+            to_json_value(&key_verification_start_content).unwrap(),
+            json_data
         );
     }
 
@@ -311,22 +321,36 @@ mod tests {
                 session_id: "session_id".to_string(),
             });
 
+        let json_data = json!({
+            "algorithm":"m.megolm.v1.aes-sha2",
+            "ciphertext":"ciphertext",
+            "sender_key":"sender_key",
+            "device_id":"device_id",
+            "session_id":"session_id"
+        });
+
         assert_eq!(
-            serde_json::from_str::<EventResult<EncryptedEventContent>>(
-                r#"{"algorithm":"m.megolm.v1.aes-sha2","ciphertext":"ciphertext","sender_key":"sender_key","device_id":"device_id","session_id":"session_id"}"#
-            )
-            .unwrap()
-            .into_result()
-            .unwrap(),
+            from_json_value::<EventResult<EncryptedEventContent>>(json_data)
+                .unwrap()
+                .into_result()
+                .unwrap(),
             key_verification_start_content
         );
     }
 
     #[test]
     fn deserialization_olm() {
-        let content = serde_json::from_str::<EventResult<EncryptedEventContent>>(
-                r#"{"sender_key":"test_key", "ciphertext":{ "test_curve_key": { "body": "encrypted_body", "type": 1 }},"algorithm": "m.olm.v1.curve25519-aes-sha2"}"#
-            )
+        let json_data = json!({
+            "sender_key":"test_key",
+            "ciphertext": {
+                "test_curve_key": {
+                    "body": "encrypted_body",
+                    "type": 1
+                }
+            },
+            "algorithm": "m.olm.v1.curve25519-aes-sha2"
+        });
+        let content = from_json_value::<EventResult<EncryptedEventContent>>(json_data)
             .unwrap()
             .into_result()
             .unwrap();
@@ -345,8 +369,8 @@ mod tests {
 
     #[test]
     fn deserialization_failure() {
-        assert!(serde_json::from_str::<EventResult<EncryptedEventContent>>(
-            r#"{"algorithm":"m.megolm.v1.aes-sha2"}"#
+        assert!(from_json_value::<EventResult<EncryptedEventContent>>(
+            json!({"algorithm":"m.megolm.v1.aes-sha2"})
         )
         .unwrap()
         .into_result()

--- a/src/room/member.rs
+++ b/src/room/member.rs
@@ -357,7 +357,7 @@ mod tests {
                 }
             },
             "event_id": "$143273582443PhrSn:example.org",
-            "origin_server_ts":233,
+            "origin_server_ts": 233,
             "room_id": "!jEsUZKDJdhlrceRyVU:example.org",
             "sender": "@alice:example.org",
             "state_key": "@alice:example.org"

--- a/src/room/message.rs
+++ b/src/room/message.rs
@@ -1067,9 +1067,9 @@ mod tests {
         assert_eq!(
             to_json_value(&message_event_content).unwrap(),
             json!({
-                "body":"test",
-                "msgtype":"m.audio",
-                "url":"http://example.com/audio.mp3"
+                "body": "test",
+                "msgtype": "m.audio",
+                "url": "http://example.com/audio.mp3"
             })
         );
     }
@@ -1083,8 +1083,8 @@ mod tests {
         assert_eq!(
             to_json_value(&message_event_content).unwrap(),
             json!({
-                "body":"> <@test:example.com> test\n\ntest reply",
-                "msgtype":"m.text"
+                "body": "> <@test:example.com> test\n\ntest reply",
+                "msgtype": "m.text"
             })
         );
     }
@@ -1103,11 +1103,11 @@ mod tests {
         });
 
         let json_data = json!({
-            "body":"> <@test:example.com> test\n\ntest reply",
-            "msgtype":"m.text",
-            "m.relates_to":{
-                "m.in_reply_to":{
-                    "event_id":"$15827405538098VGFWH:example.com"
+            "body": "> <@test:example.com> test\n\ntest reply",
+            "msgtype": "m.text",
+            "m.relates_to": {
+                "m.in_reply_to": {
+                    "event_id": "$15827405538098VGFWH:example.com"
                 }
             }
         });
@@ -1125,9 +1125,9 @@ mod tests {
         });
 
         let json_data = json!({
-            "body":"test",
-            "msgtype":"m.audio",
-            "url":"http://example.com/audio.mp3"
+            "body": "test",
+            "msgtype": "m.audio",
+            "url": "http://example.com/audio.mp3"
         });
 
         assert_eq!(
@@ -1141,8 +1141,10 @@ mod tests {
 
     #[test]
     fn deserialization_failure() {
-        let json_data =
-            json!({"body":"test","msgtype":"m.location","url":"http://example.com/audio.mp3"});
+        let json_data = json!({
+            "body": "test","msgtype": "m.location",
+            "url": "http://example.com/audio.mp3"
+        });
         assert!(
             from_json_value::<EventResult<MessageEventContent>>(json_data)
                 .unwrap()

--- a/src/room/message.rs
+++ b/src/room/message.rs
@@ -1047,7 +1047,9 @@ impl Serialize for VideoMessageEventContent {
 
 #[cfg(test)]
 mod tests {
-    use serde_json::to_string;
+    use serde_json::from_value as from_json_value;
+    use serde_json::json;
+    use serde_json::to_value as to_json_value;
 
     use super::{AudioMessageEventContent, MessageEventContent};
     use crate::room::message::{InReplyTo, RelatesTo, TextMessageEventContent};
@@ -1065,8 +1067,12 @@ mod tests {
         });
 
         assert_eq!(
-            to_string(&message_event_content).unwrap(),
-            r#"{"body":"test","msgtype":"m.audio","url":"http://example.com/audio.mp3"}"#
+            to_json_value(&message_event_content).unwrap(),
+            json!({
+                "body":"test",
+                "msgtype":"m.audio",
+                "url":"http://example.com/audio.mp3"
+            })
         );
     }
 
@@ -1077,8 +1083,11 @@ mod tests {
         ));
 
         assert_eq!(
-            to_string(&message_event_content).unwrap(),
-            r#"{"body":"> <@test:example.com> test\n\ntest reply","msgtype":"m.text"}"#
+            to_json_value(&message_event_content).unwrap(),
+            json!({
+                "body":"> <@test:example.com> test\n\ntest reply",
+                "msgtype":"m.text"
+            })
         );
     }
 
@@ -1095,10 +1104,17 @@ mod tests {
             }),
         });
 
-        assert_eq!(
-            to_string(&message_event_content).unwrap(),
-            r#"{"body":"> <@test:example.com> test\n\ntest reply","msgtype":"m.text","m.relates_to":{"m.in_reply_to":{"event_id":"$15827405538098VGFWH:example.com"}}}"#
-        );
+        let json_data = json!({
+            "body":"> <@test:example.com> test\n\ntest reply",
+            "msgtype":"m.text",
+            "m.relates_to":{
+                "m.in_reply_to":{
+                    "event_id":"$15827405538098VGFWH:example.com"
+                }
+            }
+        });
+
+        assert_eq!(to_json_value(&message_event_content).unwrap(), json_data);
     }
 
     #[test]
@@ -1110,24 +1126,30 @@ mod tests {
             file: None,
         });
 
+        let json_data = json!({
+            "body":"test",
+            "msgtype":"m.audio",
+            "url":"http://example.com/audio.mp3"
+        });
+
         assert_eq!(
-            serde_json::from_str::<EventResult<MessageEventContent>>(
-                r#"{"body":"test","msgtype":"m.audio","url":"http://example.com/audio.mp3"}"#
-            )
-            .unwrap()
-            .into_result()
-            .unwrap(),
+            from_json_value::<EventResult<MessageEventContent>>(json_data)
+                .unwrap()
+                .into_result()
+                .unwrap(),
             message_event_content
         );
     }
 
     #[test]
     fn deserialization_failure() {
-        assert!(serde_json::from_str::<EventResult<MessageEventContent>>(
-            r#"{"body":"test","msgtype":"m.location","url":"http://example.com/audio.mp3"}"#
-        )
-        .unwrap()
-        .into_result()
-        .is_err());
+        let json_data =
+            json!({"body":"test","msgtype":"m.location","url":"http://example.com/audio.mp3"});
+        assert!(
+            from_json_value::<EventResult<MessageEventContent>>(json_data)
+                .unwrap()
+                .into_result()
+                .is_err()
+        );
     }
 }

--- a/src/room/message.rs
+++ b/src/room/message.rs
@@ -1047,9 +1047,7 @@ impl Serialize for VideoMessageEventContent {
 
 #[cfg(test)]
 mod tests {
-    use serde_json::from_value as from_json_value;
-    use serde_json::json;
-    use serde_json::to_value as to_json_value;
+    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
     use super::{AudioMessageEventContent, MessageEventContent};
     use crate::room::message::{InReplyTo, RelatesTo, TextMessageEventContent};

--- a/src/room/name.rs
+++ b/src/room/name.rs
@@ -197,9 +197,7 @@ mod tests {
 
     use js_int::UInt;
     use ruma_identifiers::{EventId, RoomId, UserId};
-    use serde_json::from_value as from_json_value;
-    use serde_json::to_value as to_json_value;
-    use serde_json::{json, Map};
+    use serde_json::{from_value as from_json_value, json, to_value as to_json_value, Map};
 
     use crate::EventResult;
 

--- a/src/room/name.rs
+++ b/src/room/name.rs
@@ -197,7 +197,9 @@ mod tests {
 
     use js_int::UInt;
     use ruma_identifiers::{EventId, RoomId, UserId};
-    use serde_json::Map;
+    use serde_json::from_value as from_json_value;
+    use serde_json::to_value as to_json_value;
+    use serde_json::{json, Map};
 
     use crate::EventResult;
 
@@ -218,8 +220,17 @@ mod tests {
             unsigned: Map::new(),
         };
 
-        let actual = serde_json::to_string(&name_event).unwrap();
-        let expected = r#"{"content":{"name":"The room name"},"event_id":"$h29iv0s8:example.com","origin_server_ts":1,"sender":"@carl:example.com","state_key":"","type":"m.room.name"}"#;
+        let actual = to_json_value(&name_event).unwrap();
+        let expected = json!({
+            "content": {
+                "name":"The room name"
+            },
+            "event_id":"$h29iv0s8:example.com",
+            "origin_server_ts":1,
+            "sender":"@carl:example.com",
+            "state_key":"",
+            "type":"m.room.name"
+        });
 
         assert_eq!(actual, expected);
     }
@@ -241,18 +252,38 @@ mod tests {
             unsigned: serde_json::from_str(r#"{"foo":"bar"}"#).unwrap(),
         };
 
-        let actual = serde_json::to_string(&name_event).unwrap();
-        let expected = r#"{"content":{"name":"The room name"},"event_id":"$h29iv0s8:example.com","origin_server_ts":1,"prev_content":{"name":"The old name"},"room_id":"!n8f893n9:example.com","sender":"@carl:example.com","state_key":"","type":"m.room.name","unsigned":{"foo":"bar"}}"#;
+        let actual = to_json_value(&name_event).unwrap();
+        let expected = json!({
+            "content": {
+                "name":"The room name"
+            },
+            "event_id":"$h29iv0s8:example.com",
+            "origin_server_ts":1,
+            "prev_content":{"name":"The old name"},
+            "room_id":"!n8f893n9:example.com",
+            "sender":"@carl:example.com",
+            "state_key":"",
+            "type":"m.room.name",
+            "unsigned": {
+                "foo":"bar"
+            }
+        });
 
         assert_eq!(actual, expected);
     }
 
     #[test]
     fn absent_field_as_none() {
+        let json_data = json!({
+            "content":{},
+            "event_id":"$h29iv0s8:example.com",
+            "origin_server_ts":1,
+            "sender":"@carl:example.com",
+            "state_key":"",
+            "type":"m.room.name"
+        });
         assert_eq!(
-            serde_json::from_str::<EventResult<NameEvent>>(
-                r#"{"content":{},"event_id":"$h29iv0s8:example.com","origin_server_ts":1,"sender":"@carl:example.com","state_key":"","type":"m.room.name"}"#
-            )
+            from_json_value::<EventResult<NameEvent>>(json_data)
                 .unwrap()
                 .into_result()
                 .unwrap()
@@ -300,10 +331,18 @@ mod tests {
 
     #[test]
     fn null_field_as_none() {
+        let json_data = json!({
+            "content":{
+                "name":null
+            },
+            "event_id":"$h29iv0s8:example.com",
+            "origin_server_ts":1,
+            "sender":"@carl:example.com",
+            "state_key":"",
+            "type":"m.room.name"
+        });
         assert_eq!(
-            serde_json::from_str::<EventResult<NameEvent>>(
-                r#"{"content":{"name":null},"event_id":"$h29iv0s8:example.com","origin_server_ts":1,"sender":"@carl:example.com","state_key":"","type":"m.room.name"}"#
-            )
+            from_json_value::<EventResult<NameEvent>>(json_data)
                 .unwrap()
                 .into_result()
                 .unwrap()
@@ -315,10 +354,18 @@ mod tests {
 
     #[test]
     fn empty_string_as_none() {
+        let json_data = json!({
+            "content": {
+                "name": ""
+            },
+            "event_id":"$h29iv0s8:example.com",
+            "origin_server_ts":1,
+            "sender":"@carl:example.com",
+            "state_key":"",
+            "type":"m.room.name"
+        });
         assert_eq!(
-            serde_json::from_str::<EventResult<NameEvent>>(
-                r#"{"content":{"name":""},"event_id":"$h29iv0s8:example.com","origin_server_ts":1,"sender":"@carl:example.com","state_key":"","type":"m.room.name"}"#
-            )
+            from_json_value::<EventResult<NameEvent>>(json_data)
                 .unwrap()
                 .into_result()
                 .unwrap()
@@ -331,11 +378,19 @@ mod tests {
     #[test]
     fn nonempty_field_as_some() {
         let name = Some("The room name".to_string());
+        let json_data = json!({
+            "content": {
+                "name":"The room name"
+            },
+            "event_id":"$h29iv0s8:example.com",
+            "origin_server_ts":1,
+            "sender":"@carl:example.com",
+            "state_key":"",
+            "type":"m.room.name"
+        });
 
         assert_eq!(
-            serde_json::from_str::<EventResult<NameEvent>>(
-                r#"{"content":{"name":"The room name"},"event_id":"$h29iv0s8:example.com","origin_server_ts":1,"sender":"@carl:example.com","state_key":"","type":"m.room.name"}"#
-            )
+            from_json_value::<EventResult<NameEvent>>(json_data)
                 .unwrap()
                 .into_result()
                 .unwrap()

--- a/src/room/name.rs
+++ b/src/room/name.rs
@@ -221,13 +221,13 @@ mod tests {
         let actual = to_json_value(&name_event).unwrap();
         let expected = json!({
             "content": {
-                "name":"The room name"
+                "name": "The room name"
             },
-            "event_id":"$h29iv0s8:example.com",
-            "origin_server_ts":1,
-            "sender":"@carl:example.com",
-            "state_key":"",
-            "type":"m.room.name"
+            "event_id": "$h29iv0s8:example.com",
+            "origin_server_ts": 1,
+            "sender": "@carl:example.com",
+            "state_key": "",
+            "type": "m.room.name"
         });
 
         assert_eq!(actual, expected);
@@ -247,23 +247,23 @@ mod tests {
             room_id: Some(RoomId::try_from("!n8f893n9:example.com").unwrap()),
             sender: UserId::try_from("@carl:example.com").unwrap(),
             state_key: "".to_string(),
-            unsigned: serde_json::from_str(r#"{"foo":"bar"}"#).unwrap(),
+            unsigned: serde_json::from_str(r#"{"foo": "bar"}"#).unwrap(),
         };
 
         let actual = to_json_value(&name_event).unwrap();
         let expected = json!({
             "content": {
-                "name":"The room name"
+                "name": "The room name"
             },
-            "event_id":"$h29iv0s8:example.com",
-            "origin_server_ts":1,
-            "prev_content":{"name":"The old name"},
-            "room_id":"!n8f893n9:example.com",
-            "sender":"@carl:example.com",
-            "state_key":"",
-            "type":"m.room.name",
+            "event_id": "$h29iv0s8:example.com",
+            "origin_server_ts": 1,
+            "prev_content": {"name": "The old name"},
+            "room_id": "!n8f893n9:example.com",
+            "sender": "@carl:example.com",
+            "state_key": "",
+            "type": "m.room.name",
             "unsigned": {
-                "foo":"bar"
+                "foo": "bar"
             }
         });
 
@@ -273,12 +273,12 @@ mod tests {
     #[test]
     fn absent_field_as_none() {
         let json_data = json!({
-            "content":{},
-            "event_id":"$h29iv0s8:example.com",
-            "origin_server_ts":1,
-            "sender":"@carl:example.com",
-            "state_key":"",
-            "type":"m.room.name"
+            "content": {},
+            "event_id": "$h29iv0s8:example.com",
+            "origin_server_ts": 1,
+            "sender": "@carl:example.com",
+            "state_key": "",
+            "type": "m.room.name"
         });
         assert_eq!(
             from_json_value::<EventResult<NameEvent>>(json_data)
@@ -330,14 +330,14 @@ mod tests {
     #[test]
     fn null_field_as_none() {
         let json_data = json!({
-            "content":{
-                "name":null
+            "content": {
+                "name": null
             },
-            "event_id":"$h29iv0s8:example.com",
-            "origin_server_ts":1,
-            "sender":"@carl:example.com",
-            "state_key":"",
-            "type":"m.room.name"
+            "event_id": "$h29iv0s8:example.com",
+            "origin_server_ts": 1,
+            "sender": "@carl:example.com",
+            "state_key": "",
+            "type": "m.room.name"
         });
         assert_eq!(
             from_json_value::<EventResult<NameEvent>>(json_data)
@@ -356,11 +356,11 @@ mod tests {
             "content": {
                 "name": ""
             },
-            "event_id":"$h29iv0s8:example.com",
-            "origin_server_ts":1,
-            "sender":"@carl:example.com",
-            "state_key":"",
-            "type":"m.room.name"
+            "event_id": "$h29iv0s8:example.com",
+            "origin_server_ts": 1,
+            "sender": "@carl:example.com",
+            "state_key": "",
+            "type": "m.room.name"
         });
         assert_eq!(
             from_json_value::<EventResult<NameEvent>>(json_data)
@@ -378,13 +378,13 @@ mod tests {
         let name = Some("The room name".to_string());
         let json_data = json!({
             "content": {
-                "name":"The room name"
+                "name": "The room name"
             },
-            "event_id":"$h29iv0s8:example.com",
-            "origin_server_ts":1,
-            "sender":"@carl:example.com",
-            "state_key":"",
-            "type":"m.room.name"
+            "event_id": "$h29iv0s8:example.com",
+            "origin_server_ts": 1,
+            "sender": "@carl:example.com",
+            "state_key": "",
+            "type": "m.room.name"
         });
 
         assert_eq!(

--- a/src/room/power_levels.rs
+++ b/src/room/power_levels.rs
@@ -308,8 +308,7 @@ mod tests {
     use js_int::{Int, UInt};
     use maplit::hashmap;
     use ruma_identifiers::{EventId, RoomId, UserId};
-    use serde_json::to_value as to_json_value;
-    use serde_json::{json, Map};
+    use serde_json::{json, to_value as to_json_value, Map};
 
     use super::{
         default_power_level, NotificationPowerLevels, PowerLevelsEvent, PowerLevelsEventContent,

--- a/src/room/power_levels.rs
+++ b/src/room/power_levels.rs
@@ -343,12 +343,12 @@ mod tests {
 
         let actual = to_json_value(&power_levels_event).unwrap();
         let expected = json!({
-            "content":{},
-            "event_id":"$h29iv0s8:example.com",
-            "origin_server_ts":1,
-            "sender":"@carl:example.com",
-            "state_key":"",
-            "type":"m.room.power_levels"
+            "content": {},
+            "event_id": "$h29iv0s8:example.com",
+            "origin_server_ts": 1,
+            "sender": "@carl:example.com",
+            "state_key": "",
+            "type": "m.room.power_levels"
         });
 
         assert_eq!(actual, expected);
@@ -398,57 +398,57 @@ mod tests {
                 },
             }),
             room_id: Some(RoomId::try_from("!n8f893n9:example.com").unwrap()),
-            unsigned: serde_json::from_str(r#"{"foo":"bar"}"#).unwrap(),
+            unsigned: serde_json::from_str(r#"{"foo": "bar"}"#).unwrap(),
             sender: user,
             state_key: "".to_string(),
         };
 
         let actual = to_json_value(&power_levels_event).unwrap();
         let expected = json!({
-            "content":{
-                "ban":23,
-                "events":{
-                    "m.dummy":23
+            "content": {
+                "ban": 23,
+                "events": {
+                    "m.dummy": 23
                 },
-                "events_default":23,
-                "invite":23,
-                "kick":23,
-                "redact":23,
-                "state_default":23,
-                "users":{
-                    "@carl:example.com":23
+                "events_default": 23,
+                "invite": 23,
+                "kick": 23,
+                "redact": 23,
+                "state_default": 23,
+                "users": {
+                    "@carl:example.com": 23
                 },
-                "users_default":23,
-                "notifications":{
-                    "room":23
+                "users_default": 23,
+                "notifications": {
+                    "room": 23
                 }
             },
-            "event_id":"$h29iv0s8:example.com",
-            "origin_server_ts":1,
-            "prev_content":{
-                "ban":42,
-                "events":{
-                    "m.dummy":42
+            "event_id": "$h29iv0s8:example.com",
+            "origin_server_ts": 1,
+            "prev_content": {
+                "ban": 42,
+                "events": {
+                    "m.dummy": 42
                 },
-                "events_default":42,
-                "invite":42,
-                "kick":42,
-                "redact":42,
-                "state_default":42,
-                "users":{
-                    "@carl:example.com":42
+                "events_default": 42,
+                "invite": 42,
+                "kick": 42,
+                "redact": 42,
+                "state_default": 42,
+                "users": {
+                    "@carl:example.com": 42
                 },
-                "users_default":42,
-                "notifications":{
-                    "room":42
+                "users_default": 42,
+                "notifications": {
+                    "room": 42
                 }
             },
-            "room_id":"!n8f893n9:example.com",
-            "sender":"@carl:example.com",
-            "state_key":"",
-            "type":"m.room.power_levels",
-            "unsigned":{
-                "foo":"bar"
+            "room_id": "!n8f893n9:example.com",
+            "sender": "@carl:example.com",
+            "state_key": "",
+            "type": "m.room.power_levels",
+            "unsigned": {
+                "foo": "bar"
             }
         });
 

--- a/src/room/power_levels.rs
+++ b/src/room/power_levels.rs
@@ -308,7 +308,8 @@ mod tests {
     use js_int::{Int, UInt};
     use maplit::hashmap;
     use ruma_identifiers::{EventId, RoomId, UserId};
-    use serde_json::Map;
+    use serde_json::to_value as to_json_value;
+    use serde_json::{json, Map};
 
     use super::{
         default_power_level, NotificationPowerLevels, PowerLevelsEvent, PowerLevelsEventContent,
@@ -341,8 +342,15 @@ mod tests {
             state_key: "".to_string(),
         };
 
-        let actual = serde_json::to_string(&power_levels_event).unwrap();
-        let expected = r#"{"content":{},"event_id":"$h29iv0s8:example.com","origin_server_ts":1,"sender":"@carl:example.com","state_key":"","type":"m.room.power_levels"}"#;
+        let actual = to_json_value(&power_levels_event).unwrap();
+        let expected = json!({
+            "content":{},
+            "event_id":"$h29iv0s8:example.com",
+            "origin_server_ts":1,
+            "sender":"@carl:example.com",
+            "state_key":"",
+            "type":"m.room.power_levels"
+        });
 
         assert_eq!(actual, expected);
     }
@@ -396,8 +404,54 @@ mod tests {
             state_key: "".to_string(),
         };
 
-        let actual = serde_json::to_string(&power_levels_event).unwrap();
-        let expected = r#"{"content":{"ban":23,"events":{"m.dummy":23},"events_default":23,"invite":23,"kick":23,"redact":23,"state_default":23,"users":{"@carl:example.com":23},"users_default":23,"notifications":{"room":23}},"event_id":"$h29iv0s8:example.com","origin_server_ts":1,"prev_content":{"ban":42,"events":{"m.dummy":42},"events_default":42,"invite":42,"kick":42,"redact":42,"state_default":42,"users":{"@carl:example.com":42},"users_default":42,"notifications":{"room":42}},"room_id":"!n8f893n9:example.com","sender":"@carl:example.com","state_key":"","type":"m.room.power_levels","unsigned":{"foo":"bar"}}"#;
+        let actual = to_json_value(&power_levels_event).unwrap();
+        let expected = json!({
+            "content":{
+                "ban":23,
+                "events":{
+                    "m.dummy":23
+                },
+                "events_default":23,
+                "invite":23,
+                "kick":23,
+                "redact":23,
+                "state_default":23,
+                "users":{
+                    "@carl:example.com":23
+                },
+                "users_default":23,
+                "notifications":{
+                    "room":23
+                }
+            },
+            "event_id":"$h29iv0s8:example.com",
+            "origin_server_ts":1,
+            "prev_content":{
+                "ban":42,
+                "events":{
+                    "m.dummy":42
+                },
+                "events_default":42,
+                "invite":42,
+                "kick":42,
+                "redact":42,
+                "state_default":42,
+                "users":{
+                    "@carl:example.com":42
+                },
+                "users_default":42,
+                "notifications":{
+                    "room":42
+                }
+            },
+            "room_id":"!n8f893n9:example.com",
+            "sender":"@carl:example.com",
+            "state_key":"",
+            "type":"m.room.power_levels",
+            "unsigned":{
+                "foo":"bar"
+            }
+        });
 
         assert_eq!(actual, expected);
     }

--- a/src/room/server_acl.rs
+++ b/src/room/server_acl.rs
@@ -180,8 +180,7 @@ pub(crate) mod raw {
 
 #[cfg(test)]
 mod tests {
-    use serde_json::from_value as from_json_value;
-    use serde_json::json;
+    use serde_json::{from_value as from_json_value, json};
 
     use super::ServerAclEvent;
     use crate::EventResult;

--- a/src/room/server_acl.rs
+++ b/src/room/server_acl.rs
@@ -187,7 +187,13 @@ mod tests {
 
     #[test]
     fn default_values() {
-        let json_data = json!({"content":{},"event_id":"$h29iv0s8:example.com","origin_server_ts":1,"sender":"@carl:example.com","state_key":"","type":"m.room.server_acl"});
+        let json_data = json!({
+            "content": {},
+            "event_id": "$h29iv0s8:example.com","origin_server_ts":1,
+            "sender": "@carl:example.com",
+            "state_key": "",
+            "type": "m.room.server_acl"
+        });
         let server_acl_event: ServerAclEvent = from_json_value::<EventResult<_>>(json_data)
             .unwrap()
             .into_result()

--- a/src/room/server_acl.rs
+++ b/src/room/server_acl.rs
@@ -180,14 +180,19 @@ pub(crate) mod raw {
 
 #[cfg(test)]
 mod tests {
+    use serde_json::from_value as from_json_value;
+    use serde_json::json;
+
     use super::ServerAclEvent;
     use crate::EventResult;
 
     #[test]
     fn default_values() {
-        let server_acl_event: ServerAclEvent =
-            serde_json::from_str::<EventResult<_>>(r#"{"content":{},"event_id":"$h29iv0s8:example.com","origin_server_ts":1,"sender":"@carl:example.com","state_key":"","type":"m.room.server_acl"}"#)
-            .unwrap().into_result().unwrap();
+        let json_data = json!({"content":{},"event_id":"$h29iv0s8:example.com","origin_server_ts":1,"sender":"@carl:example.com","state_key":"","type":"m.room.server_acl"});
+        let server_acl_event: ServerAclEvent = from_json_value::<EventResult<_>>(json_data)
+            .unwrap()
+            .into_result()
+            .unwrap();
 
         assert_eq!(server_acl_event.content.allow_ip_literals, true);
         assert!(server_acl_event.content.allow.is_empty());

--- a/src/stripped.rs
+++ b/src/stripped.rs
@@ -312,7 +312,9 @@ mod tests {
 
     use js_int::UInt;
     use ruma_identifiers::UserId;
-    use serde_json::to_string;
+    use serde_json::from_value as from_json_value;
+    use serde_json::json;
+    use serde_json::to_value as to_json_value;
 
     use super::{AnyStrippedStateEvent, StrippedRoomName, StrippedRoomTopic};
     use crate::{
@@ -333,29 +335,35 @@ mod tests {
 
         let event = AnyStrippedStateEvent::RoomTopic(content);
 
-        assert_eq!(
-            to_string(&event).unwrap(),
-            r#"{"content":{"topic":"Testing room"},"type":"m.room.topic","state_key":"","sender":"@example:localhost"}"#
-        );
+        let json_data = json!({
+            "content": {
+                "topic":"Testing room"
+            },
+            "type":"m.room.topic",
+            "state_key":"",
+            "sender":"@example:localhost"
+        });
+
+        assert_eq!(to_json_value(&event).unwrap(), json_data);
     }
 
     #[test]
     fn deserialize_stripped_state_events() {
-        let name_event = r#"{
+        let name_event = json!({
             "type": "m.room.name",
             "state_key": "",
             "sender": "@example:localhost",
             "content": {"name": "Ruma"}
-        }"#;
+        });
 
-        let join_rules_event = r#"{
+        let join_rules_event = json!({
             "type": "m.room.join_rules",
             "state_key": "",
             "sender": "@example:localhost",
             "content": { "join_rule": "public" }
-        }"#;
+        });
 
-        let avatar_event = r#"{
+        let avatar_event = json!({
             "type": "m.room.avatar",
             "state_key": "",
             "sender": "@example:localhost",
@@ -382,9 +390,9 @@ mod tests {
                 "thumbnail_url": "https://example.com/image-thumbnail.jpg",
                 "url": "https://example.com/image.jpg"
             }
-        }"#;
+        });
 
-        match serde_json::from_str::<EventResult<_>>(name_event)
+        match from_json_value::<EventResult<_>>(name_event.clone())
             .unwrap()
             .into_result()
             .unwrap()
@@ -399,14 +407,12 @@ mod tests {
         };
 
         // Ensure `StrippedStateContent` can be parsed, not just `StrippedState`.
-        assert!(
-            serde_json::from_str::<EventResult<StrippedRoomName>>(name_event)
-                .unwrap()
-                .into_result()
-                .is_ok()
-        );
+        assert!(from_json_value::<EventResult<StrippedRoomName>>(name_event)
+            .unwrap()
+            .into_result()
+            .is_ok());
 
-        match serde_json::from_str::<EventResult<_>>(join_rules_event)
+        match from_json_value::<EventResult<_>>(join_rules_event)
             .unwrap()
             .into_result()
             .unwrap()
@@ -420,7 +426,7 @@ mod tests {
             _ => unreachable!(),
         };
 
-        match serde_json::from_str::<EventResult<_>>(avatar_event)
+        match from_json_value::<EventResult<_>>(avatar_event)
             .unwrap()
             .into_result()
             .unwrap()

--- a/src/stripped.rs
+++ b/src/stripped.rs
@@ -312,9 +312,7 @@ mod tests {
 
     use js_int::UInt;
     use ruma_identifiers::UserId;
-    use serde_json::from_value as from_json_value;
-    use serde_json::json;
-    use serde_json::to_value as to_json_value;
+    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
     use super::{AnyStrippedStateEvent, StrippedRoomName, StrippedRoomTopic};
     use crate::{

--- a/src/stripped.rs
+++ b/src/stripped.rs
@@ -335,11 +335,11 @@ mod tests {
 
         let json_data = json!({
             "content": {
-                "topic":"Testing room"
+                "topic": "Testing room"
             },
-            "type":"m.room.topic",
-            "state_key":"",
-            "sender":"@example:localhost"
+            "type": "m.room.topic",
+            "state_key": "",
+            "sender": "@example:localhost"
         });
 
         assert_eq!(to_json_value(&event).unwrap(), json_data);

--- a/src/to_device.rs
+++ b/src/to_device.rs
@@ -635,7 +635,7 @@ mod tests {
                 "methods": [
                     "m.sas.v1"
                 ],
-                "timestamp": 1559598944869u64,
+                "timestamp": 1_559_598_944_869_u64,
                 "transaction_id": "S0meUniqueAndOpaqueString"
             },
             "type": "m.key.verification.request",
@@ -646,6 +646,9 @@ mod tests {
         assert_eq!(event.content.transaction_id, "S0meUniqueAndOpaqueString");
         assert_eq!(event.content.from_device, "AliceDevice2");
         assert_eq!(event.content.methods, &[VerificationMethod::MSasV1]);
-        assert_eq!(event.content.timestamp, UInt::new(1559_598944869).unwrap());
+        assert_eq!(
+            event.content.timestamp,
+            UInt::new(1_559_598_944_869).unwrap()
+        );
     }
 }

--- a/src/to_device.rs
+++ b/src/to_device.rs
@@ -261,6 +261,8 @@ mod tests {
     use js_int::UInt;
 
     use ruma_identifiers::{RoomId, UserId};
+    use serde_json::from_value as from_json_value;
+    use serde_json::json;
 
     use super::AnyToDeviceEvent;
     use crate::{
@@ -275,10 +277,10 @@ mod tests {
 
     macro_rules! deserialize {
         ($source:ident, $($target:tt)*) => {{
-            let event = serde_json::from_str::<EventResult<AnyToDeviceEvent>>($source)
+            let event = from_json_value::<EventResult<AnyToDeviceEvent>>($source)
                 .expect(&format!(
                     "Can't deserialize to-device event: {} from source {}",
-                    stringify!($($target)*), $source
+                    stringify!($($target)*), stringify!($source)
                 ));
 
             let event = event
@@ -303,11 +305,11 @@ mod tests {
 
     #[test]
     fn dummy() {
-        let dummy = r#"{
+        let dummy = json!({
             "content": {},
             "sender": "@alice:example.org",
             "type": "m.dummy"
-        }"#;
+        });
 
         let event = deserialize! {dummy, AnyToDeviceEvent::Dummy};
 
@@ -316,7 +318,7 @@ mod tests {
 
     #[test]
     fn room_key() {
-        let room_key = r#"{
+        let room_key = json!({
             "content": {
                 "algorithm": "m.megolm.v1.aes-sha2",
                 "room_id": "!test:localhost",
@@ -325,7 +327,7 @@ mod tests {
             },
             "sender": "@alice:example.org",
             "type": "m.room_key"
-        }"#;
+        });
 
         let event = deserialize! {room_key, AnyToDeviceEvent::RoomKey};
 
@@ -340,7 +342,7 @@ mod tests {
 
     #[test]
     fn encrypted_olm() {
-        let source = r#"{
+        let source = json!({
             "content": {
                 "sender_key": "test_sender_key",
                 "ciphertext": {
@@ -357,7 +359,7 @@ mod tests {
             },
             "type": "m.room.encrypted",
             "sender": "@alice:example.org"
-        }"#;
+        });
 
         let event = deserialize! {source, AnyToDeviceEvent::RoomEncrypted};
 
@@ -377,7 +379,7 @@ mod tests {
 
     #[test]
     fn forwarded_room_key() {
-        let source = r#"{
+        let source = json!({
             "content": {
                 "algorithm": "m.megolm.v1.aes-sha2",
                 "forwarding_curve25519_key_chain": [
@@ -391,7 +393,7 @@ mod tests {
             },
             "sender": "@alice:example.org",
             "type": "m.forwarded_room_key"
-        }"#;
+        });
 
         let event = deserialize! {source, AnyToDeviceEvent::ForwardedRoomKey};
 
@@ -414,7 +416,7 @@ mod tests {
 
     #[test]
     fn key_request() {
-        let source = r#"{
+        let source = json!({
             "sender": "@alice:example.org",
             "content": {
                 "action": "request",
@@ -428,7 +430,7 @@ mod tests {
                 "requesting_device_id": "RJYKSTBOIE"
             },
             "type": "m.room_key_request"
-        }"#;
+        });
 
         let event = deserialize! {source, AnyToDeviceEvent::RoomKeyRequest};
         let body = event.content.body.as_ref().unwrap();
@@ -449,7 +451,7 @@ mod tests {
 
     #[test]
     fn key_request_cancel() {
-        let source = r#"{
+        let source = json!({
             "sender": "@alice:example.org",
             "content": {
                 "action": "request_cancellation",
@@ -457,7 +459,7 @@ mod tests {
                 "requesting_device_id": "RJYKSTBOIE"
             },
             "type": "m.room_key_request"
-        }"#;
+        });
 
         let event = deserialize! {source, AnyToDeviceEvent::RoomKeyRequest};
         assert_eq!(event.content.action, Action::CancelRequest);
@@ -467,7 +469,7 @@ mod tests {
 
     #[test]
     fn key_verification_start() {
-        let source = r#"{
+        let source = json!({
             "content": {
                 "from_device": "AliceDevice1",
                 "hashes": [
@@ -488,7 +490,7 @@ mod tests {
             },
             "type": "m.key.verification.start",
             "sender": "@alice:example.org"
-        }"#;
+        });
 
         let event = deserialize! {source, AnyToDeviceEvent::KeyVerificationStart};
 
@@ -519,7 +521,7 @@ mod tests {
 
     #[test]
     fn key_verification_accept() {
-        let source = r#"{
+        let source = json!({
             "content": {
                 "commitment": "fQpGIW1Snz+pwLZu6sTy2aHy/DYWWTspTJRPyNp0PKkymfIsNffysMl6ObMMFdIJhk6g6pwlIqZ54rxo8SLmAg",
                 "hash": "sha256",
@@ -534,7 +536,7 @@ mod tests {
             },
             "type": "m.key.verification.accept",
             "sender": "@alice:example.org"
-        }"#;
+        });
 
         let event = deserialize! {source, AnyToDeviceEvent::KeyVerificationAccept};
         assert_eq!(event.content.hash, HashAlgorithm::Sha256);
@@ -563,14 +565,14 @@ mod tests {
 
     #[test]
     fn key_verification_key() {
-        let source = r#"{
+        let source = json!({
             "content": {
                 "key": "fQpGIW1Snz+pwLZu6sTy2aHy/DYWWTspTJRPyNp0PKkymfIsNffysMl6ObMMFdIJhk6g6pwlIqZ54rxo8SLmAg",
                 "transaction_id": "S0meUniqueAndOpaqueString"
             },
             "type": "m.key.verification.key",
             "sender": "@alice:example.org"
-        }"#;
+        });
 
         let event = deserialize! {source, AnyToDeviceEvent::KeyVerificationKey};
 
@@ -583,7 +585,7 @@ mod tests {
 
     #[test]
     fn key_verification_mac() {
-        let source = r#"{
+        let source = json!({
             "content": {
                 "keys": "2Wptgo4CwmLo/Y8B8qinxApKaCkBG2fjTWB7AbP5Uy+aIbygsSdLOFzvdDjww8zUVKCmI02eP9xtyJxc/cLiBA",
                 "mac": {
@@ -593,7 +595,7 @@ mod tests {
             },
             "type": "m.key.verification.mac",
             "sender": "@alice:example.org"
-        }"#;
+        });
 
         let event = deserialize! {source, AnyToDeviceEvent::KeyVerificationMac};
         assert_eq!(event.content.transaction_id, "S0meUniqueAndOpaqueString");
@@ -609,7 +611,7 @@ mod tests {
 
     #[test]
     fn key_verification_cancel() {
-        let source = r#"{
+        let source = json!({
             "content": {
                 "code": "m.user",
                 "reason": "Some reason",
@@ -617,7 +619,7 @@ mod tests {
             },
             "type": "m.key.verification.cancel",
             "sender": "@alice:example.org"
-        }"#;
+        });
 
         let event = deserialize! {source, AnyToDeviceEvent::KeyVerificationCancel};
         assert_eq!(event.content.transaction_id, "S0meUniqueAndOpaqueString");
@@ -627,18 +629,18 @@ mod tests {
 
     #[test]
     fn key_verification_request() {
-        let source = r#"{
+        let source = json!({
             "content": {
                 "from_device": "AliceDevice2",
                 "methods": [
                     "m.sas.v1"
                 ],
-                "timestamp": 1559598944869,
+                "timestamp": 1559598944869u64,
                 "transaction_id": "S0meUniqueAndOpaqueString"
             },
             "type": "m.key.verification.request",
             "sender": "@alice:example.org"
-        }"#;
+        });
 
         let event = deserialize! {source, AnyToDeviceEvent::KeyVerificationRequest};
         assert_eq!(event.content.transaction_id, "S0meUniqueAndOpaqueString");

--- a/src/to_device.rs
+++ b/src/to_device.rs
@@ -261,8 +261,7 @@ mod tests {
     use js_int::UInt;
 
     use ruma_identifiers::{RoomId, UserId};
-    use serde_json::from_value as from_json_value;
-    use serde_json::json;
+    use serde_json::{from_value as from_json_value, json};
 
     use super::AnyToDeviceEvent;
     use crate::{


### PR DESCRIPTION
- [x] event_type.rs
- [x] presence.rs
- [x] ignored_user_list.rs
- [x] push_rules.rs
- [x] to_device.rs
- [x] direct.rs
- [x] dummy.rs
- [x] stripped.rs
- [x] key/verification/start.rs
- [x] key/verification/cancel.rs
- [x] room/pinned_events.rs
- [x] room/name.rs
- [x] room/canonical_alias.rs
- [x] room/member.rs
- [x] room/create.rs
- [x] room/power_levels.rs
- [x] room/message.rs
- [x] room/encrypted.rs
- [x] room/server_acl.rs

